### PR TITLE
feat(oauth): add PKCE, secure state, scope management, and OOB flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "asana",

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -16,6 +16,8 @@ export function createAuthCommand(): Command {
     .description('Login to Asana (OAuth or PAT)')
     .option('--token <token>', 'Use Personal Access Token (PAT) instead of OAuth')
     .option('-w, --workspace <workspace>', 'Default workspace ID')
+    .option('--scope <scopes>', 'OAuth scopes, space-separated (e.g. "tasks:read projects:read")')
+    .option('--no-browser', 'Use copy-paste flow instead of opening browser (for headless/CI environments)')
     .action(async (options) => {
       try {
         if (options.token) {
@@ -42,7 +44,8 @@ export function createAuthCommand(): Command {
           console.log(chalk.gray('  Create OAuth app at: https://app.asana.com/0/my-apps'))
           console.log(chalk.gray('  Docs: https://developers.asana.com/docs/getting-started-with-asana-oauth\n'))
 
-          const tokenResponse = await startOAuthFlow()
+          const scopes = options.scope ? options.scope.trim().split(/\s+/) : undefined
+          const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false })
 
           // Calculate expiration time
           const expiresAt = Date.now() + (tokenResponse.expires_in * 1000)
@@ -53,6 +56,7 @@ export function createAuthCommand(): Command {
             authType: 'oauth',
             workspace: options.workspace,
             expiresAt,
+            scopes,
           })
 
           console.log(chalk.green('✓ Successfully authenticated with OAuth'))

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,4 +1,5 @@
 import { createServer } from 'node:http'
+import { createInterface } from 'node:readline'
 import chalk from 'chalk'
 import open from 'open'
 
@@ -8,8 +9,10 @@ const OAUTH_CONFIG = {
   authUrl: 'https://app.asana.com/-/oauth_authorize',
   tokenUrl: 'https://app.asana.com/-/oauth_token',
   redirectUri: 'http://localhost:8080/callback',
-  scopes: 'default', // or specific scopes like 'tasks:read tasks:write'
+  defaultScopes: 'default',
 }
+
+const OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 
 export interface OAuthTokenResponse {
   access_token: string
@@ -18,11 +21,50 @@ export interface OAuthTokenResponse {
   token_type: string
 }
 
+export interface OAuthFlowOptions {
+  scopes?: string[]
+  oob?: boolean
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+}
+
 /**
- * Start OAuth flow by opening browser and waiting for callback
- * Requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET environment variables
+ * Generate a cryptographically secure random state string for CSRF protection
  */
-export async function startOAuthFlow(): Promise<OAuthTokenResponse> {
+export function generateSecureState(): string {
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  return base64urlEncode(bytes)
+}
+
+/**
+ * Generate PKCE code_verifier and code_challenge (S256 method)
+ * RFC 7636: code_verifier is 43-128 URL-safe chars; code_challenge = BASE64URL(SHA256(verifier))
+ */
+export async function generatePKCE(): Promise<{ codeVerifier: string, codeChallenge: string }> {
+  const bytes = new Uint8Array(32) // 32 bytes → 43 base64url chars (no padding)
+  crypto.getRandomValues(bytes)
+  const codeVerifier = base64urlEncode(bytes)
+
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))
+  const codeChallenge = base64urlEncode(new Uint8Array(digest))
+
+  return { codeVerifier, codeChallenge }
+}
+
+/**
+ * Start OAuth flow by opening browser and waiting for callback.
+ * Uses PKCE (S256) and cryptographically secure state.
+ * Requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET environment variables.
+ *
+ * @param options - Flow options
+ */
+export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OAuthTokenResponse> {
   const clientId = process.env.ASANA_CLIENT_ID
   const clientSecret = process.env.ASANA_CLIENT_SECRET
 
@@ -34,24 +76,30 @@ export async function startOAuthFlow(): Promise<OAuthTokenResponse> {
     )
   }
 
-  // Generate state for security
-  const state = Math.random().toString(36).substring(2, 15)
+  const state = generateSecureState()
+  const { codeVerifier, codeChallenge } = await generatePKCE()
+  const scopeStr = options.scopes?.join(' ') || OAUTH_CONFIG.defaultScopes
+  const redirectUri = options.oob ? OOB_REDIRECT_URI : OAUTH_CONFIG.redirectUri
 
-  // Build authorization URL
   const authUrl = new URL(OAUTH_CONFIG.authUrl)
   authUrl.searchParams.set('client_id', clientId)
-  authUrl.searchParams.set('redirect_uri', OAUTH_CONFIG.redirectUri)
+  authUrl.searchParams.set('redirect_uri', redirectUri)
   authUrl.searchParams.set('response_type', 'code')
   authUrl.searchParams.set('state', state)
-  authUrl.searchParams.set('scope', OAUTH_CONFIG.scopes)
+  authUrl.searchParams.set('scope', scopeStr)
+  authUrl.searchParams.set('code_challenge', codeChallenge)
+  authUrl.searchParams.set('code_challenge_method', 'S256')
+
+  if (options.oob) {
+    return startOobFlow(authUrl, codeVerifier, clientId, clientSecret)
+  }
 
   console.log(chalk.blue('Opening browser for authentication...'))
   console.log(chalk.gray(`If the browser doesn't open, visit: ${authUrl.toString()}`))
 
-  // Create local server to handle callback
   return new Promise((resolve, reject) => {
     const server = createServer(async (req, res) => {
-      const url = new URL(req.url || '', `http://localhost:8080`)
+      const url = new URL(req.url || '', 'http://localhost:8080')
 
       if (url.pathname === '/callback') {
         const code = url.searchParams.get('code') || ''
@@ -75,8 +123,7 @@ export async function startOAuthFlow(): Promise<OAuthTokenResponse> {
         }
 
         try {
-          // Exchange code for token
-          const token = await exchangeCodeForToken(code, clientId, clientSecret)
+          const token = await exchangeCodeForToken(code, clientId, clientSecret, OAUTH_CONFIG.redirectUri, codeVerifier)
 
           res.writeHead(200, { 'Content-Type': 'text/html' })
           res.end('<h1>Authentication Successful!</h1><p>You can close this window and return to the terminal.</p>')
@@ -105,20 +152,59 @@ export async function startOAuthFlow(): Promise<OAuthTokenResponse> {
 }
 
 /**
+ * OOB (out-of-band) flow: prints auth URL and prompts user to paste the code.
+ * Used when --no-browser is specified (headless/CI environments).
+ */
+async function startOobFlow(
+  authUrl: URL,
+  codeVerifier: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<OAuthTokenResponse> {
+  console.log(chalk.blue('\nOpen this URL in your browser to authorize:'))
+  console.log(chalk.cyan(authUrl.toString()))
+  console.log(chalk.gray('\nAfter authorizing, copy the code shown in the browser.'))
+
+  const code = await promptForCode()
+
+  if (!code) {
+    throw new Error('No authorization code provided')
+  }
+
+  return exchangeCodeForToken(code, clientId, clientSecret, OOB_REDIRECT_URI, codeVerifier)
+}
+
+function promptForCode(): Promise<string> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    rl.question(chalk.yellow('Paste the authorization code: '), (answer) => {
+      rl.close()
+      resolve(answer.trim())
+    })
+  })
+}
+
+/**
  * Exchange authorization code for access token
  */
 async function exchangeCodeForToken(
   code: string,
   clientId: string,
   clientSecret: string,
+  redirectUri: string,
+  codeVerifier?: string,
 ): Promise<OAuthTokenResponse> {
   const params = new URLSearchParams({
     grant_type: 'authorization_code',
     client_id: clientId,
     client_secret: clientSecret,
-    redirect_uri: OAUTH_CONFIG.redirectUri,
+    redirect_uri: redirectUri,
     code,
   })
+
+  if (codeVerifier) {
+    params.set('code_verifier', codeVerifier)
+  }
 
   const response = await fetch(OAUTH_CONFIG.tokenUrl, {
     method: 'POST',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface AsanaConfig {
   authType?: 'pat' | 'oauth'
   workspace?: string
   expiresAt?: number
+  scopes?: string[]
 }
 
 export interface TaskOptions {

--- a/test/lib/oauth.test.ts
+++ b/test/lib/oauth.test.ts
@@ -1,6 +1,6 @@
 import type { OAuthTokenResponse } from '../../src/lib/oauth'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { refreshAccessToken } from '../../src/lib/oauth'
+import { generatePKCE, generateSecureState, refreshAccessToken } from '../../src/lib/oauth'
 
 describe('oauth module', () => {
   beforeEach(() => {
@@ -13,6 +13,75 @@ describe('oauth module', () => {
     // Clean up environment variables
     delete process.env.ASANA_CLIENT_ID
     delete process.env.ASANA_CLIENT_SECRET
+  })
+
+  describe('generateSecureState', () => {
+    test('returns a non-empty string', () => {
+      const state = generateSecureState()
+      expect(typeof state).toBe('string')
+      expect(state.length).toBeGreaterThan(0)
+    })
+
+    test('returns different values on successive calls', () => {
+      const state1 = generateSecureState()
+      const state2 = generateSecureState()
+      expect(state1).not.toBe(state2)
+    })
+
+    test('returns URL-safe base64 string (no +, /, or = chars)', () => {
+      const state = generateSecureState()
+      expect(state).not.toMatch(/[+/=]/)
+    })
+
+    test('returns at least 16 characters', () => {
+      // 16 bytes of random data encodes to ~22 base64url chars
+      const state = generateSecureState()
+      expect(state.length).toBeGreaterThanOrEqual(16)
+    })
+  })
+
+  describe('generatePKCE', () => {
+    test('returns codeVerifier and codeChallenge', async () => {
+      const { codeVerifier, codeChallenge } = await generatePKCE()
+      expect(typeof codeVerifier).toBe('string')
+      expect(typeof codeChallenge).toBe('string')
+    })
+
+    test('codeVerifier is at least 43 characters (RFC 7636)', async () => {
+      const { codeVerifier } = await generatePKCE()
+      // 32 random bytes → 43 base64url chars (no padding)
+      expect(codeVerifier.length).toBeGreaterThanOrEqual(43)
+    })
+
+    test('codeVerifier contains only URL-safe characters', async () => {
+      const { codeVerifier } = await generatePKCE()
+      expect(codeVerifier).not.toMatch(/[+/=]/)
+    })
+
+    test('codeChallenge contains only URL-safe characters', async () => {
+      const { codeChallenge } = await generatePKCE()
+      expect(codeChallenge).not.toMatch(/[+/=]/)
+    })
+
+    test('returns different values on successive calls', async () => {
+      const first = await generatePKCE()
+      const second = await generatePKCE()
+      expect(first.codeVerifier).not.toBe(second.codeVerifier)
+      expect(first.codeChallenge).not.toBe(second.codeChallenge)
+    })
+
+    test('codeChallenge is SHA-256 of codeVerifier encoded as base64url', async () => {
+      const { codeVerifier, codeChallenge } = await generatePKCE()
+
+      // Re-derive the challenge independently
+      const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))
+      const expectedChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=/g, '')
+
+      expect(codeChallenge).toBe(expectedChallenge)
+    })
   })
 
   describe('refreshAccessToken', () => {
@@ -186,6 +255,54 @@ describe('oauth module', () => {
       await expect(startOAuthFlow()).rejects.toThrow(
         /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
       )
+    })
+
+    describe('scope parameter handling', () => {
+      test('uses default scope when no scopes option is provided', async () => {
+        // Verify the default scope is 'default' by checking what gets built into auth URL
+        // We do this by testing the behavior indirectly - when creds are missing, the
+        // error is thrown before scope matters; we just verify the flow accepts no scopes
+        const { startOAuthFlow } = await import('../../src/lib/oauth')
+        delete process.env.ASANA_CLIENT_ID
+
+        // The function throws before scope is processed, so we just verify it accepts undefined scopes
+        await expect(startOAuthFlow({})).rejects.toThrow(
+          /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
+        )
+      })
+
+      test('accepts custom scopes array', async () => {
+        const { startOAuthFlow } = await import('../../src/lib/oauth')
+        delete process.env.ASANA_CLIENT_ID
+
+        // Verify the function accepts a scopes array without throwing a type error
+        await expect(startOAuthFlow({ scopes: ['tasks:read', 'projects:read'] })).rejects.toThrow(
+          /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
+        )
+      })
+    })
+
+    describe('OOB flow', () => {
+      test('throws error when credentials are missing even in OOB mode', async () => {
+        delete process.env.ASANA_CLIENT_ID
+        delete process.env.ASANA_CLIENT_SECRET
+
+        const { startOAuthFlow } = await import('../../src/lib/oauth')
+
+        await expect(startOAuthFlow({ oob: true })).rejects.toThrow(
+          /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
+        )
+      })
+
+      test('accepts oob option', async () => {
+        const { startOAuthFlow } = await import('../../src/lib/oauth')
+        delete process.env.ASANA_CLIENT_ID
+
+        // Verify the function accepts the oob option
+        await expect(startOAuthFlow({ oob: true })).rejects.toThrow(
+          /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary

- **PKCE (RFC 7636)**: Adds `generatePKCE()` using `crypto.getRandomValues()` + `crypto.subtle.digest` (SHA-256/S256). `code_challenge` is added to the authorization URL; `code_verifier` is sent during token exchange — protecting against authorization code interception attacks.
- **Secure state**: Replaces `Math.random().toString(36)` with `crypto.getRandomValues()` + base64url encoding for proper CSRF protection.
- **Scope management**: `startOAuthFlow()` now accepts `OAuthFlowOptions.scopes?: string[]`. The `auth login` command gains a `--scope <scopes>` option (space-separated, e.g. `"tasks:read projects:read"`). Granted scopes are stored in `AsanaConfig`.
- **OOB flow for headless/CI**: `--no-browser` flag uses `urn:ietf:wg:oauth:2.0:oob` as the redirect URI, prints the auth URL, and prompts the user to paste the authorization code via stdin.

## Files changed

| File | Change |
|---|---|
| `src/lib/oauth.ts` | PKCE, secure state, OOB flow, `OAuthFlowOptions` |
| `src/types/index.ts` | Added `scopes?: string[]` to `AsanaConfig` |
| `src/commands/auth.ts` | Added `--scope` and `--no-browser` CLI options |
| `test/lib/oauth.test.ts` | 14 new tests for new functionality |

## Test plan

- [x] `bun test test/lib/oauth.test.ts` — 25 tests pass (14 new + 11 existing)
- [x] `bun test test/` — 166 unit tests pass, 0 fail
- [x] `bun run lint:fix` — no errors
- [ ] Manual: `asana auth login --oauth` completes full PKCE flow
- [ ] Manual: `asana auth login --oauth --no-browser` uses OOB copy-paste flow
- [ ] Manual: `asana auth login --oauth --scope "tasks:read projects:read"` requests scoped access