### PR TITLE
docs: add please workspace and ARCHITECTURE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Install dependencies
         run: bun install
@@ -43,8 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Install dependencies
         run: bun install
@@ -68,8 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/e2e-tests-secure.yml
+++ b/.github/workflows/e2e-tests-secure.yml
@@ -20,10 +20,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,10 +20,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,10 +53,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
+      - name: Setup mise (node + bun)
+        uses: jdx/mise-action@v2
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Compiled binary
 asana
+
+# please plugin runtime state
+.please/state/

--- a/.please/INDEX.md
+++ b/.please/INDEX.md
@@ -1,0 +1,35 @@
+# .please/ Workspace Index
+
+> Central navigation for all project artifacts managed by the please plugin.
+
+## Project Documents
+
+| Document | Purpose |
+|---|---|
+| [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | Repository-level bird's-eye view |
+| [`../CLAUDE.md`](../CLAUDE.md) | Project-level AI instructions |
+
+## Directory Map
+
+| Path | Purpose |
+|---|---|
+| `state/` | Runtime session state (progress) — not tracked in git |
+| `docs/tracks/` | Implementation tracks (spec + plan) → [Tracks](docs/tracks.jsonl) |
+| `docs/product-specs/` | Product-level specifications → [Product Specs Index](docs/product-specs/index.md) |
+| `docs/decisions/` | Architecture Decision Records → [Decisions Index](docs/decisions/index.md) |
+| `docs/investigations/` | Bug investigation reports |
+| `docs/research/` | Research documents |
+| `docs/references/` | External reference materials (-llms.txt etc.) |
+| `docs/knowledge/` | Stable project context (product, tech-stack, guidelines) |
+| `templates/` | Workflow templates (plugin-provided) |
+| `scripts/` | Utility scripts (plugin-provided) |
+
+## Configuration
+
+See [config.yml](config.yml) for workspace settings.
+
+## Workflows
+
+- `/please:new-track` — Create feature specification and architecture plan
+- `/please:implement` — TDD implementation from plan file
+- `/please:finalize` — Finalize PR, move track to completed

--- a/.please/INDEX.md
+++ b/.please/INDEX.md
@@ -4,25 +4,25 @@
 
 ## Project Documents
 
-| Document | Purpose |
-|---|---|
+| Document                                   | Purpose                          |
+| ------------------------------------------ | -------------------------------- |
 | [`../ARCHITECTURE.md`](../ARCHITECTURE.md) | Repository-level bird's-eye view |
-| [`../CLAUDE.md`](../CLAUDE.md) | Project-level AI instructions |
+| [`../CLAUDE.md`](../CLAUDE.md)             | Project-level AI instructions    |
 
 ## Directory Map
 
-| Path | Purpose |
-|---|---|
-| `state/` | Runtime session state (progress) — not tracked in git |
-| `docs/tracks/` | Implementation tracks (spec + plan) → [Tracks](docs/tracks.jsonl) |
-| `docs/product-specs/` | Product-level specifications → [Product Specs Index](docs/product-specs/index.md) |
-| `docs/decisions/` | Architecture Decision Records → [Decisions Index](docs/decisions/index.md) |
-| `docs/investigations/` | Bug investigation reports |
-| `docs/research/` | Research documents |
-| `docs/references/` | External reference materials (-llms.txt etc.) |
-| `docs/knowledge/` | Stable project context (product, tech-stack, guidelines) |
-| `templates/` | Workflow templates (plugin-provided) |
-| `scripts/` | Utility scripts (plugin-provided) |
+| Path                   | Purpose                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `state/`               | Runtime session state (progress) — not tracked in git                             |
+| `docs/tracks/`         | Implementation tracks (spec + plan) → [Tracks](docs/tracks.jsonl)                 |
+| `docs/product-specs/`  | Product-level specifications → [Product Specs Index](docs/product-specs/index.md) |
+| `docs/decisions/`      | Architecture Decision Records → [Decisions Index](docs/decisions/index.md)        |
+| `docs/investigations/` | Bug investigation reports                                                         |
+| `docs/research/`       | Research documents                                                                |
+| `docs/references/`     | External reference materials (-llms.txt etc.)                                     |
+| `docs/knowledge/`      | Stable project context (product, tech-stack, guidelines)                          |
+| `templates/`           | Workflow templates (plugin-provided)                                              |
+| `scripts/`             | Utility scripts (plugin-provided)                                                 |
 
 ## Configuration
 

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -1,6 +1,6 @@
-schema_version: 5          # Config schema version (do not edit manually)
+schema_version: 5 # Config schema version (do not edit manually)
 
-language: en               # Output language (ko | en)
+language: en # Output language (ko | en)
 
 # GitHub integration (optional)
 # github:

--- a/.please/config.yml
+++ b/.please/config.yml
@@ -1,0 +1,29 @@
+schema_version: 5          # Config schema version (do not edit manually)
+
+language: en               # Output language (ko | en)
+
+# GitHub integration (optional)
+# github:
+#   project: 5              # GitHub Project number (from URL: /orgs/{org}/projects/5)
+#   owner: pleaseai        # GitHub org or user owning the project
+#   issue_required: true     # Create GitHub Issue for every track (default: false)
+
+# Workflow policies (optional)
+# Populated by /please:setup when a stack tool is detected and user opts in.
+# The `tool` field selects which CLI drives the stack (currently only `graphite`).
+# workflow:
+#   stacked_pr:
+#     enabled: true                  # Use stacked PR workflow (one PR per branch in stack)
+#     tool: graphite                 # graphite | git-spice | none
+#     split_phases: true             # If plan.md has `### Phase N:` headings, create a stacked branch per phase
+#     branch_prefix: tracks/         # Branch prefix (single-phase: tracks/{track_id}; multi-phase: tracks/{track_id}/phase-N-{slug})
+
+# Document path overrides (optional — defaults shown)
+docs:
+  tracks: .please/docs/tracks
+  product-specs: .please/docs/product-specs
+  decisions: .please/docs/decisions
+  investigations: .please/docs/investigations
+  research: .please/docs/research
+  references: .please/docs/references
+  knowledge: .please/docs/knowledge

--- a/.please/docs/decisions/index.md
+++ b/.please/docs/decisions/index.md
@@ -1,0 +1,6 @@
+# Decisions Index
+
+> Auto-maintained by /please:plan.
+
+| ADR | Title | Date | Status |
+|-----|-------|------|--------|

--- a/.please/docs/decisions/index.md
+++ b/.please/docs/decisions/index.md
@@ -3,4 +3,4 @@
 > Auto-maintained by /please:plan.
 
 | ADR | Title | Date | Status |
-|-----|-------|------|--------|
+| --- | ----- | ---- | ------ |

--- a/.please/docs/knowledge/product-guidelines.md
+++ b/.please/docs/knowledge/product-guidelines.md
@@ -10,8 +10,9 @@
   `project`, `section`, `self-update`.
 - **Composable & scriptable**: every command must be usable non-interactively. Avoid
   prompts in scripted paths; accept all required input via flags.
-- **Machine-readable by choice**: support `--format toon|json|plain`. Default to a
-  human-friendly format for TTY; allow explicit format selection for pipelines.
+- **Machine-readable by choice**: support `--format toon|json|plain`. Default to
+  `toon` (token-efficient, LLM-friendly); allow explicit `json`/`plain` selection for
+  scripting and human reading.
 - **Fast feedback**: keep startup and execution snappy; defer heavy work until needed.
 
 ## Output & Messaging

--- a/.please/docs/knowledge/product-guidelines.md
+++ b/.please/docs/knowledge/product-guidelines.md
@@ -1,0 +1,42 @@
+# Product Guidelines
+
+> Branding, UX, and style conventions for the Asana CLI. Consulted during implementation
+> and review.
+
+## CLI UX Principles
+
+- **Predictable command structure**: `asana <resource> <action> [options]`
+  (e.g. `asana task create`, `asana project list`). Resources: `auth`, `task`,
+  `project`, `section`, `self-update`.
+- **Composable & scriptable**: every command must be usable non-interactively. Avoid
+  prompts in scripted paths; accept all required input via flags.
+- **Machine-readable by choice**: support `--format toon|json|plain`. Default to a
+  human-friendly format for TTY; allow explicit format selection for pipelines.
+- **Fast feedback**: keep startup and execution snappy; defer heavy work until needed.
+
+## Output & Messaging
+
+- Use **chalk** for color, but degrade gracefully when output is not a TTY (no color
+  codes in piped/JSON output).
+- Success and error messages are concise, actionable, and written in clear English.
+- Errors are routed through a central error handler (`src/lib/error-handler.ts`) and
+  present a clear user-facing message — never a raw stack trace by default.
+- Exit codes are meaningful: `0` on success, non-zero on failure.
+
+## Branding
+
+- Product name: **Asana CLI** (binary: `asana`).
+- License: MIT. Maintained under the `pleaseai` GitHub org.
+- Documentation is bilingual where it matters (English primary, Korean `README.ko.md`).
+
+## Security & Privacy
+
+- **Never log secrets** (tokens, OAuth codes). Use dotenvx-encrypted `.env.secrets`.
+- Validate and normalize all user input (`src/lib/validators.ts`).
+- Store credentials in the user's local config, not in the repository.
+
+## Code Style
+
+- Follow **@antfu/eslint-config** (ESLint flat config in `eslint.config.js`).
+- TypeScript throughout; prefer explicit, intention-revealing names.
+- Keep commands thin — push reusable logic into `src/lib/` and `src/utils/`.

--- a/.please/docs/knowledge/product.md
+++ b/.please/docs/knowledge/product.md
@@ -1,0 +1,49 @@
+# Product Guide
+
+> Stable product context for the Asana CLI. Consulted before planning and implementation.
+
+## Vision
+
+A fast, scriptable command-line interface for managing Asana tasks without leaving the
+terminal. Built for developers and power users who live in the shell and want Asana
+workflows to be automatable, pipeable, and quick.
+
+## Target Users
+
+- **Developers** who manage their own work in Asana and prefer terminal-native tooling.
+- **Power users / team leads** who want to script repetitive Asana operations
+  (bulk task creation, status sweeps, reporting).
+- **Automation / CI authors** who need machine-readable Asana output (TOON/JSON) to
+  pipe into other tools.
+
+## Goals
+
+- Provide first-class CRUD over Asana **tasks**, **projects**, and **sections** from the CLI.
+- Support both **OAuth 2.0** and **Personal Access Token** authentication, with automatic
+  OAuth token refresh.
+- Offer **multiple output formats** — TOON (token-efficient), JSON (machine-readable),
+  and Plain (human-readable) — selectable per command.
+- Stay **fast** by leveraging the Bun runtime and shipping as a compiled single binary.
+- Distribute easily via Homebrew, an install script, and source builds.
+
+## Core Features
+
+- **Authentication**: `auth login` via PAT or OAuth, automatic token refresh, default
+  workspace configuration.
+- **Tasks**: create, list, complete, and delete tasks.
+- **Projects & Sections**: manage projects and their sections.
+- **Self-update**: `self-update` command to upgrade the installed binary.
+- **Output formatting**: switchable TOON / JSON / Plain output for interactive and
+  scripted use.
+
+## Non-Goals
+
+- Not a full Asana web-UI replacement; focuses on the most common task-management flows.
+- Not a long-running daemon or sync service; each invocation is a discrete command.
+- No GUI; terminal-only by design.
+
+## Constraints
+
+- Requires the **Bun** runtime for development; ships as a compiled binary for end users.
+- Depends on the official **Asana API** and its rate limits / availability.
+- Secrets (tokens) must never be logged; managed via dotenvx-encrypted environment files.

--- a/.please/docs/knowledge/tech-stack.md
+++ b/.please/docs/knowledge/tech-stack.md
@@ -1,0 +1,63 @@
+# Tech Stack
+
+> Authoritative technology choices for the Asana CLI. Changes here must precede
+> implementation that deviates from the documented stack.
+
+## Runtime & Language
+
+- **Bun** — primary runtime and toolchain (dev, test, build, package manager).
+  The project standardizes on Bun over Node.js.
+- **TypeScript** (`^5`) — all source code. ESM (`"type": "module"`).
+
+## Core Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `commander` (^14) | CLI argument parsing and command structure |
+| `asana` (^3.1) | Official Asana API SDK |
+| `@pleaseai/cli-toolkit` (^0.2) | Shared CLI utilities (org toolkit) |
+| `chalk` (^5) | Terminal colors |
+| `open` (^10) | Open URLs/browser (OAuth flow) |
+| `@dotenvx/dotenvx` (^1.51) | Encrypted environment variable / secrets management |
+
+## Tooling
+
+| Tool | Purpose |
+|------|---------|
+| `bun test` | Test runner (unit in `test/`, e2e in `tests/e2e`) |
+| `eslint` (^9) + `@antfu/eslint-config` (^6) | Linting and formatting (flat config) |
+| `eslint-plugin-format` | Formatting via ESLint |
+| `turbo` (^2.5) | Task orchestration |
+| `dotenvx` | `env:encrypt` / `env:decrypt`, secure run wrappers |
+
+## Build & Distribution
+
+- **Build**: `bun build src/index.ts --compile --outfile asana` → single compiled binary.
+- **Entry point**: `src/index.ts` (bin: `asana`).
+- **Distribution**: Homebrew tap (`pleaseai/tap/asana-cli`), install script
+  (`scripts/install.sh`), and from-source builds.
+
+## Source Layout
+
+```
+src/
+├── index.ts          # CLI entry point
+├── commands/         # Command handlers: auth, task, project, section, self-update
+├── lib/              # Core logic: asana-client, config, error-handler, oauth, validators
+├── utils/            # formatter (TOON/JSON/Plain output)
+├── constants/        # Shared constants
+└── types/            # Shared TypeScript types
+```
+
+## Authentication
+
+- **OAuth 2.0** (`src/lib/oauth.ts`) with automatic token refresh.
+- **Personal Access Token** (PAT) as the recommended/simple path.
+- Default workspace configuration persisted in local config (`src/lib/config.ts`).
+
+## Output Formats
+
+- **TOON** — token-efficient, optimized for LLM/automation consumption.
+- **JSON** — machine-readable.
+- **Plain** — human-readable terminal output.
+- Implemented in `src/utils/formatter.ts`.

--- a/.please/docs/knowledge/tech-stack.md
+++ b/.please/docs/knowledge/tech-stack.md
@@ -11,24 +11,24 @@
 
 ## Core Dependencies
 
-| Package | Purpose |
-|---------|---------|
-| `commander` (^14) | CLI argument parsing and command structure |
-| `asana` (^3.1) | Official Asana API SDK |
-| `@pleaseai/cli-toolkit` (^0.2) | Shared CLI utilities (org toolkit) |
-| `chalk` (^5) | Terminal colors |
-| `open` (^10) | Open URLs/browser (OAuth flow) |
-| `@dotenvx/dotenvx` (^1.51) | Encrypted environment variable / secrets management |
+| Package                        | Purpose                                             |
+| ------------------------------ | --------------------------------------------------- |
+| `commander` (^14)              | CLI argument parsing and command structure          |
+| `asana` (^3.1)                 | Official Asana API SDK                              |
+| `@pleaseai/cli-toolkit` (^0.2) | Shared CLI utilities (org toolkit)                  |
+| `chalk` (^5)                   | Terminal colors                                     |
+| `open` (^10)                   | Open URLs/browser (OAuth flow)                      |
+| `@dotenvx/dotenvx` (^1.51)     | Encrypted environment variable / secrets management |
 
 ## Tooling
 
-| Tool | Purpose |
-|------|---------|
-| `bun test` | Test runner (unit in `test/`, e2e in `tests/e2e`) |
-| `eslint` (^9) + `@antfu/eslint-config` (^6) | Linting and formatting (flat config) |
-| `eslint-plugin-format` | Formatting via ESLint |
-| `turbo` (^2.5) | Task orchestration |
-| `dotenvx` | `env:encrypt` / `env:decrypt`, secure run wrappers |
+| Tool                                        | Purpose                                            |
+| ------------------------------------------- | -------------------------------------------------- |
+| `bun test`                                  | Test runner (unit in `test/`, e2e in `tests/e2e`)  |
+| `eslint` (^9) + `@antfu/eslint-config` (^6) | Linting and formatting (flat config)               |
+| `eslint-plugin-format`                      | Formatting via ESLint                              |
+| `turbo` (^2.5)                              | Task orchestration                                 |
+| `dotenvx`                                   | `env:encrypt` / `env:decrypt`, secure run wrappers |
 
 ## Build & Distribution
 

--- a/.please/docs/knowledge/workflow.md
+++ b/.please/docs/knowledge/workflow.md
@@ -1,0 +1,137 @@
+# Project Workflow
+
+> Development workflow conventions for the Asana CLI.
+> Referenced by `/please:implement`.
+
+## Guiding Principles
+
+1. **The Plan is the Source of Truth**: All work is tracked in the track's `plan.md`
+2. **The Tech Stack is Deliberate**: Changes to the tech stack must be documented in `tech-stack.md` before implementation
+3. **Test-Driven Development**: Write tests before implementing functionality
+4. **High Code Coverage**: Aim for >80% code coverage for new code
+5. **Non-Interactive & CI-Aware**: Prefer non-interactive commands. Use `CI=true` for watch-mode tools
+
+## Task Workflow
+
+All tasks follow a strict lifecycle within `/please:implement`:
+
+### Standard Task Lifecycle
+
+1. **Select Task**: Choose the next available task from `plan.md`
+2. **Mark In Progress**: Update task status from `[ ]` to `[~]`
+3. **Write Failing Tests (Red Phase)**:
+   - Create test file for the feature or bug fix
+   - Write unit tests defining expected behavior
+   - Run tests and confirm they fail as expected
+4. **Implement to Pass Tests (Green Phase)**:
+   - Write minimum code to make failing tests pass
+   - Run test suite and confirm all tests pass
+5. **Refactor (Optional)**:
+   - Improve clarity, remove duplication, enhance performance
+   - Rerun tests to ensure they still pass
+6. **Verify Coverage**: Run coverage reports. Target: >80% for new code
+7. **Document Deviations**: If implementation differs from tech stack, update `tech-stack.md` first
+8. **Commit**: Stage and commit with conventional commit message (one commit per task)
+9. **Update Progress**: Mark the task as completed in `## Progress` with a timestamp
+
+### Phase Completion Protocol
+
+Executed when all tasks in a phase are complete:
+
+1. **Verify Test Coverage**: Identify all files changed in the phase, ensure test coverage
+2. **Run Full Test Suite**: Execute all tests, debug failures (max 2 fix attempts)
+3. **Manual Verification Plan**: Generate step-by-step verification instructions for the user
+4. **User Confirmation**: Wait for explicit user approval before proceeding
+5. **Create Checkpoint**: Commit with message `chore(checkpoint): complete phase {name}`
+6. **Update Plan**: Mark phase as complete in `plan.md`
+
+## Quality Gates
+
+Before marking any task complete:
+
+- [ ] All tests pass
+- [ ] Code coverage meets requirements (>80%)
+- [ ] Code follows project style guidelines (`@antfu/eslint-config`)
+- [ ] No linting or static analysis errors
+- [ ] No security vulnerabilities introduced (no secrets logged/committed)
+- [ ] Documentation updated if needed
+
+## Development Commands
+
+> Adapted for the Bun + TypeScript stack.
+
+### Setup
+
+```bash
+bun install
+```
+
+### Daily Development
+
+```bash
+bun run dev -- --help          # Run the CLI locally
+bun run dev:secure -- --help   # Run with dotenvx-decrypted secrets
+```
+
+### Testing
+
+```bash
+bun test test/                 # Unit tests
+bun run test:e2e               # End-to-end tests (tests/e2e)
+bun run test:coverage          # Unit tests with coverage
+bun test --watch test/         # Watch mode
+```
+
+### Before Committing
+
+```bash
+bun run lint:fix               # ESLint autofix
+bun run lint                   # Lint check
+bun test                       # Full test suite
+```
+
+### Build
+
+```bash
+bun run build                  # Compile single binary (./asana)
+```
+
+## Testing Requirements
+
+### Unit Testing
+
+- Every module must have corresponding tests under `test/`
+- Mock external dependencies (Asana API, OAuth, filesystem)
+- Test both success and failure cases
+
+### Integration / E2E Testing
+
+- Test complete CLI command flows under `tests/e2e`
+- Verify authentication and authorization paths
+- Use `dotenvx` (`test:e2e:secure`) when secrets are required
+
+## Commit Guidelines
+
+Follow the project's commit convention (`@commitlint/config-conventional`).
+See `Skill("standards:commit-convention")` for details.
+
+### Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation only
+- `style`: Formatting changes
+- `refactor`: Code change without behavior change
+- `test`: Adding or updating tests
+- `chore`: Maintenance tasks
+
+## Definition of Done
+
+A task is complete when:
+
+1. All code implemented to specification
+2. Unit tests written and passing
+3. Code coverage meets project requirements (>80%)
+4. Code passes lint and all configured checks
+5. Progress updated in `plan.md`
+6. Changes committed with a proper conventional commit message

--- a/.please/docs/product-specs/index.md
+++ b/.please/docs/product-specs/index.md
@@ -1,0 +1,6 @@
+# Product Specs Index
+
+> Auto-maintained by /please:spec --product.
+
+| Spec | Feature | Created | Related Tracks |
+|------|---------|---------|----------------|

--- a/.please/docs/product-specs/index.md
+++ b/.please/docs/product-specs/index.md
@@ -3,4 +3,4 @@
 > Auto-maintained by /please:spec --product.
 
 | Spec | Feature | Created | Related Tracks |
-|------|---------|---------|----------------|
+| ---- | ------- | ------- | -------------- |

--- a/.please/docs/tracks/tech-debt-tracker.md
+++ b/.please/docs/tracks/tech-debt-tracker.md
@@ -1,0 +1,13 @@
+# Tech Debt Tracker
+
+> Tracked across all tracks. Updated during implementation and retrospectives.
+
+## Active
+
+| ID | Source Track | Description | Priority | Created |
+|----|------------|-------------|----------|---------|
+
+## Resolved
+
+| ID | Source Track | Description | Resolved In | Date |
+|----|------------|-------------|-------------|------|

--- a/.please/docs/tracks/tech-debt-tracker.md
+++ b/.please/docs/tracks/tech-debt-tracker.md
@@ -4,10 +4,10 @@
 
 ## Active
 
-| ID | Source Track | Description | Priority | Created |
-|----|------------|-------------|----------|---------|
+| ID  | Source Track | Description | Priority | Created |
+| --- | ------------ | ----------- | -------- | ------- |
 
 ## Resolved
 
-| ID | Source Track | Description | Resolved In | Date |
-|----|------------|-------------|-------------|------|
+| ID  | Source Track | Description | Resolved In | Date |
+| --- | ------------ | ----------- | ----------- | ---- |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -184,9 +184,7 @@ recently expanded (`tests/e2e`).
 
 **Technical debt**: Pervasive `any` typing in the `getAsanaClient()` wrapper weakens
 type safety between commands and the SDK; tightening these types is a tracked
-improvement. The root `index.ts` at the repository root is a leftover Bun starter
-stub (`console.log('Hello via Bun!')`) and is not the CLI entry point — the real
-entry is `src/index.ts`.
+improvement.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,196 @@
+# Architecture
+
+> Agent-first ARCHITECTURE.md for the **Asana CLI** — optimized for AI agent
+> consumption (Claude Code, etc.). Describes structure and intent, not line-by-line
+> implementation. Keep this in sync when modules, entry points, or invariants change.
+
+## System Overview
+
+**Purpose**: A fast, scriptable command-line interface for managing Asana tasks,
+projects, and sections directly from the terminal, with machine-readable output for
+automation and LLM workflows.
+
+**Primary users**: Developers and power users working in the shell, automation/CI
+scripts, and AI agents that consume the token-efficient TOON output.
+
+**Core workflow**:
+
+1. The user runs `asana <resource> <action> [options]` (e.g. `asana task create -n "..."`).
+2. Commander parses the command; the command's action handler loads credentials,
+   calls the Asana API through the `getAsanaClient()` wrapper, and validates input.
+3. The result is rendered via `formatOutput()` in the globally-selected format
+   (TOON by default, or JSON / Plain) and printed; failures exit non-zero through
+   the centralized error handler.
+
+**Key constraints**:
+
+- Ships as a single compiled binary via Bun; startup must stay fast (no heavy
+  eager initialization).
+- Depends on the official Asana API and is subject to its rate limits and availability.
+- Secrets (access/refresh tokens) must never be logged or committed; they live only
+  in the user's local config (`~/.asana-cli/config.json`) or environment.
+
+## Dependency Layers
+
+Dependencies flow downward only. Lower layers must not import upper layers.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Interface Layer                                         │
+│  src/index.ts, src/commands/*                            │  Commander commands, flags
+├─────────────────────────────────────────────────────────┤
+│  Application Layer                                       │
+│  command .action() handlers                              │  Orchestration per command
+├─────────────────────────────────────────────────────────┤
+│  Domain / Core Layer                                     │
+│  src/lib/* (asana-client wrapper, validators, oauth),   │  Auth, validation, API access
+│  src/utils/formatter.ts, src/constants, src/types       │
+├─────────────────────────────────────────────────────────┤
+│  Infrastructure Layer                                   │
+│  asana SDK, filesystem (~/.asana-cli), OAuth HTTP        │  External services & I/O
+│  callback server, @pleaseai/cli-toolkit (TOON)           │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Invariant**: Command handlers reach the Asana API only through the
+`getAsanaClient()` wrapper in `src/lib/asana-client.ts` — they never instantiate
+`asana` SDK API classes directly. This keeps token handling, lazy initialization,
+and the legacy-style API surface in one place.
+
+## Entry Points
+
+For understanding **how the CLI boots and dispatches**:
+
+- `src/index.ts` — Root entry point. Builds the top-level `commander` program,
+  declares the global `-f, --format <toon|json|plain>` option (default `toon`), and
+  registers every subcommand. Start here to see the full command surface.
+
+For understanding **a typical command's shape**:
+
+- `src/commands/task.ts` — Representative command module. Shows the standard pattern:
+  define subcommands with options, validate input, call `getAsanaClient()`, then
+  render with `formatOutput()`. The global `--format` is read from the root program
+  via `command.parent?.parent?.opts().format`.
+
+For understanding **Asana API access & token lifecycle**:
+
+- `src/lib/asana-client.ts` — Lazily initializes the Asana SDK with the stored token,
+  exposes a stable legacy-style wrapper (`tasks`, `projects`, `sections`, `users`,
+  `workspaces`), and handles OAuth refresh (`refreshTokenIfNeeded`) and client reset.
+
+For understanding **authentication**:
+
+- `src/commands/auth.ts` + `src/lib/oauth.ts` — PAT and OAuth 2.0 login. `oauth.ts`
+  opens the browser and runs a localhost HTTP callback server to capture the code,
+  exchanges it for tokens, and persists them via `config.ts`.
+
+For understanding **output rendering**:
+
+- `src/utils/formatter.ts` — `formatOutput()` switches between TOON (token-efficient,
+  via `@pleaseai/cli-toolkit`), JSON, and human-readable Plain text.
+
+## Module Reference
+
+| Module | Purpose | Key Files | Depends On | Depended By |
+| --- | --- | --- | --- | --- |
+| `src/` (root) | CLI bootstrap & command registration | `index.ts` | `commands/*` | (binary entry) |
+| `src/commands/` | One module per resource; defines subcommands, flags, and orchestration | `auth.ts`, `task.ts`, `project.ts`, `section.ts`, `self-update.ts` | `lib/*`, `utils/formatter`, `types` | `index.ts` |
+| `src/lib/` | Core domain: API wrapper, auth, config persistence, validation, error handling | `asana-client.ts`, `oauth.ts`, `config.ts`, `validators.ts`, `error-handler.ts` | `asana` SDK, `node:fs/http`, `constants`, `types` | `commands/*` |
+| `src/utils/` | Output formatting across TOON / JSON / Plain | `formatter.ts` | `@pleaseai/cli-toolkit`, `chalk` | `commands/*` |
+| `src/constants/` | Stable identifiers (structured error IDs) | `errorIds.ts` | — | `lib/error-handler`, `commands/*` |
+| `src/types/` | Shared TypeScript types (config shape, command option types) | `index.ts` | — | `commands/*`, `lib/*` |
+
+## Architecture Invariants
+
+These constraints must always hold. Violating them breaks layering, leaks secrets,
+or fragments output/error behavior.
+
+**Single API gateway**: All Asana API calls go through `getAsanaClient()`
+(`src/lib/asana-client.ts`). Do NOT import or instantiate `asana` SDK API classes
+(`TasksApi`, `ProjectsApi`, …) inside `src/commands/*`. Centralizing access keeps
+lazy initialization, token injection, and OAuth refresh consistent.
+
+**All output flows through the formatter**: Command results must be rendered with
+`formatOutput()` honoring the global `--format`. Do NOT hand-roll `JSON.stringify`
+or ad-hoc `console.log` of structured data in command handlers — this would bypass
+TOON and break scripted/LLM consumers. The format is resolved from the root program
+options (`command.parent?.parent?.opts().format`), defaulting to `toon`.
+
+**Secrets never leak**: Do NOT log, print, or commit access tokens, refresh tokens,
+OAuth client secrets, or `~/.asana-cli/config.json` contents. Credentials live only
+in local config or environment variables (`ASANA_ACCESS_TOKEN`, `ASANA_CLIENT_ID`,
+`ASANA_CLIENT_SECRET`). Structured `logError` must not include token fields.
+
+**Centralized failure path**: User-facing errors terminate through
+`handleAsanaError()` / `handleHttpError()` in `src/lib/error-handler.ts`, which map
+Asana/HTTP/network errors to clear messages and `process.exit(1)`. Do NOT print raw
+stack traces by default — full details are gated behind `DEBUG`.
+
+**Input is validated at the boundary**: GIDs, dates, and update payloads pass through
+`src/lib/validators.ts` (`validateGid`, `validateDateFormat`, `validateUpdateFields`)
+before reaching the API. Validation failures raise `ValidationError`, not raw SDK errors.
+
+**Dependencies flow downward**: `src/lib/*` and `src/utils/*` must not import from
+`src/commands/*`. Core/domain code stays decoupled from the CLI interface so it
+remains unit-testable in isolation.
+
+## Cross-Cutting Concerns
+
+**Error handling**: Centralized in `src/lib/error-handler.ts`. Asana SDK structured
+errors, HTTP status codes (401/403/404/429/5xx), and network errors each get a
+tailored message plus contextual key/values, then exit `1`. `logError()` emits
+JSON-structured records to stderr when `NODE_ENV=production` (for downstream
+monitoring). Verbose diagnostics are opt-in via the `DEBUG` env var.
+
+**Logging / output**: User-facing messages use `chalk` for color but degrade for
+non-TTY output. Structured results are rendered by `src/utils/formatter.ts`. TOON is
+the default machine format (≈58.9% token savings vs JSON); `--format json` and
+`--format plain` are alternatives.
+
+**Testing**: `bun test`. Unit tests under `test/` mirror the source tree
+(`test/commands`, `test/lib`, `test/utils`, `test/helpers`); end-to-end tests live
+under `tests/e2e` (run via `bun run test:e2e`, with `test:e2e:secure` using
+dotenvx-decrypted secrets). Target >80% coverage for new code (`bun run test:coverage`).
+Mock external dependencies (Asana SDK, OAuth, filesystem).
+
+**Configuration**: Persistent credentials/workspace live in
+`~/.asana-cli/config.json`, read/written by `src/lib/config.ts`. Token resolution
+order in `getAccessToken()`: stored config, then `ASANA_ACCESS_TOKEN`. OAuth apps are
+configured via `ASANA_CLIENT_ID` / `ASANA_CLIENT_SECRET`. Secrets in the repo for
+development are managed with dotenvx (`env:encrypt` / `env:decrypt`,
+`dev:secure` / `test:e2e:secure`).
+
+**Build & distribution**: `bun build src/index.ts --compile` produces the `asana`
+binary. Distributed via a Homebrew tap (`pleaseai/tap/asana-cli`), an install script
+(`scripts/install.sh`), and from-source builds. Releases are automated with
+release-please (`release-please-config.json`, `CHANGELOG.md`).
+
+## Quality Notes
+
+**Well-tested**: `src/lib/*` and `src/utils/formatter.ts` have mirrored unit tests
+(`test/lib`, `test/utils`) and clear, isolated responsibilities — generally safe to
+refactor behind their existing interfaces. E2E coverage for the Asana API was
+recently expanded (`tests/e2e`).
+
+**Fragile / needs care**:
+
+- `src/lib/asana-client.ts` uses module-level singletons and `any`-typed wrapper
+  methods for backward compatibility. The lazy-init + `resetClient()` interplay with
+  OAuth refresh is stateful — change deliberately and re-run auth/refresh tests.
+- `formatPlain()` in `src/utils/formatter.ts` is a generic best-effort renderer; per
+  command, plain output may need shaping for the specific data structure.
+- OAuth flow (`src/lib/oauth.ts`) spins up a localhost HTTP callback server and opens
+  a browser — inherently harder to test and environment-sensitive.
+
+**Technical debt**: Pervasive `any` typing in the `getAsanaClient()` wrapper weakens
+type safety between commands and the SDK; tightening these types is a tracked
+improvement. The root `index.ts` at the repository root is a leftover Bun starter
+stub (`console.log('Hello via Bun!')`) and is not the CLI entry point — the real
+entry is `src/index.ts`.
+
+---
+
+_Last updated: 2026-06-08_
+
+_Key ADRs: none yet — record future architectural decisions under
+`.please/docs/decisions/` (use `/standards:adr`)._

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,14 +91,14 @@ For understanding **output rendering**:
 
 ## Module Reference
 
-| Module | Purpose | Key Files | Depends On | Depended By |
-| --- | --- | --- | --- | --- |
-| `src/` (root) | CLI bootstrap & command registration | `index.ts` | `commands/*` | (binary entry) |
-| `src/commands/` | One module per resource; defines subcommands, flags, and orchestration | `auth.ts`, `task.ts`, `project.ts`, `section.ts`, `self-update.ts` | `lib/*`, `utils/formatter`, `types` | `index.ts` |
-| `src/lib/` | Core domain: API wrapper, auth, config persistence, validation, error handling | `asana-client.ts`, `oauth.ts`, `config.ts`, `validators.ts`, `error-handler.ts` | `asana` SDK, `node:fs/http`, `constants`, `types` | `commands/*` |
-| `src/utils/` | Output formatting across TOON / JSON / Plain | `formatter.ts` | `@pleaseai/cli-toolkit`, `chalk` | `commands/*` |
-| `src/constants/` | Stable identifiers (structured error IDs) | `errorIds.ts` | — | `lib/error-handler`, `commands/*` |
-| `src/types/` | Shared TypeScript types (config shape, command option types) | `index.ts` | — | `commands/*`, `lib/*` |
+| Module           | Purpose                                                                        | Key Files                                                                       | Depends On                                        | Depended By                       |
+| ---------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------------- |
+| `src/` (root)    | CLI bootstrap & command registration                                           | `index.ts`                                                                      | `commands/*`                                      | (binary entry)                    |
+| `src/commands/`  | One module per resource; defines subcommands, flags, and orchestration         | `auth.ts`, `task.ts`, `project.ts`, `section.ts`, `self-update.ts`              | `lib/*`, `utils/formatter`, `types`               | `index.ts`                        |
+| `src/lib/`       | Core domain: API wrapper, auth, config persistence, validation, error handling | `asana-client.ts`, `oauth.ts`, `config.ts`, `validators.ts`, `error-handler.ts` | `asana` SDK, `node:fs/http`, `constants`, `types` | `commands/*`                      |
+| `src/utils/`     | Output formatting across TOON / JSON / Plain                                   | `formatter.ts`                                                                  | `@pleaseai/cli-toolkit`, `chalk`                  | `commands/*`                      |
+| `src/constants/` | Stable identifiers (structured error IDs)                                      | `errorIds.ts`                                                                   | —                                                 | `lib/error-handler`, `commands/*` |
+| `src/types/`     | Shared TypeScript types (config shape, command option types)                   | `index.ts`                                                                      | —                                                 | `commands/*`, `lib/*`             |
 
 ## Architecture Invariants
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,12 +119,14 @@ bun --hot ./index.ts
 For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
 
 <!-- please:knowledge v1 -->
+
 ## Project Knowledge
 
 Consult these files for project context before exploring the codebase.
 For full file listing with workspace artifacts, use `Skill("please:project-knowledge")`.
 
 ### Domain Knowledge (.please/docs/knowledge/)
+
 - `product.md` — Product vision, goals, target users
 - `product-guidelines.md` — Branding, UX principles, design system
 - `tech-stack.md` — Technology choices with rationale
@@ -133,5 +135,6 @@ For full file listing with workspace artifacts, use `Skill("please:project-knowl
 - `gotchas.md` — Known project pitfalls and workarounds
 
 ### Decision Records
+
 - `.please/docs/decisions/` — Architecture Decision Records (ADR)
 <!-- /please:knowledge -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,8 @@ For full file listing with workspace artifacts, use `Skill("please:project-knowl
 - `product-guidelines.md` — Branding, UX principles, design system
 - `tech-stack.md` — Technology choices with rationale
 - `workflow.md` — Task lifecycle, TDD, quality gates, dev commands
-- `ubiquitous-language.md` — Domain terms glossary (DDD Ubiquitous Language)
-- `gotchas.md` — Known project pitfalls and workarounds
+- `ubiquitous-language.md` — Domain terms glossary (DDD Ubiquitous Language) (planned)
+- `gotchas.md` — Known project pitfalls and workarounds (planned)
 
 ### Decision Records
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,21 @@ bun --hot ./index.ts
 ```
 
 For more information, read the Bun API docs in `node_modules/bun-types/docs/**.md`.
+
+<!-- please:knowledge v1 -->
+## Project Knowledge
+
+Consult these files for project context before exploring the codebase.
+For full file listing with workspace artifacts, use `Skill("please:project-knowledge")`.
+
+### Domain Knowledge (.please/docs/knowledge/)
+- `product.md` — Product vision, goals, target users
+- `product-guidelines.md` — Branding, UX principles, design system
+- `tech-stack.md` — Technology choices with rationale
+- `workflow.md` — Task lifecycle, TDD, quality gates, dev commands
+- `ubiquitous-language.md` — Domain terms glossary (DDD Ubiquitous Language)
+- `gotchas.md` — Known project pitfalls and workarounds
+
+### Decision Records
+- `.please/docs/decisions/` — Architecture Decision Records (ADR)
+<!-- /please:knowledge -->

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-console.log('Hello via Bun!')

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,30 @@
+# mise.toml — PassionFactory 표준 도구 체인
+# 사용법: `mise trust && mise install`
+# 상세: Skill("standards:dev-tooling")
+
+[tools]
+node = "22"
+bun = "latest"
+
+[tasks.dev]
+description = "개발 서버 실행"
+run = "bun run dev"
+
+[tasks.build]
+description = "빌드"
+run = "bun run build"
+
+[tasks.lint]
+description = "린트"
+run = "bun run lint"
+
+[tasks.test]
+description = "테스트"
+run = "bun run test"
+
+[tasks.check]
+description = "lint → test 일괄 검사"
+depends = [
+  "lint",
+  "test"
+]


### PR DESCRIPTION
## Summary

Initialize the `.please/` workspace scaffolding and add repository-level documentation to support the please plugin workflow.

## Changes

- **`.please/` workspace**: config.yml, INDEX.md, docs/tracks.jsonl, tech-debt-tracker.md, product-specs/index.md, decisions/index.md, and knowledge docs (product.md, product-guidelines.md, tech-stack.md, workflow.md)
- **`CLAUDE.md`**: Added `<!-- please:knowledge v1 -->` project-knowledge block so the please plugin can load workspace context automatically
- **`.gitignore`**: Added `.please/state/` to exclude please plugin runtime state from version control
- **`ARCHITECTURE.md`**: New bird's-eye-view document describing the repository structure and architectural conventions

## Test Plan

- [ ] Verify `.please/state/` is gitignored and not included in this PR
- [ ] Confirm please plugin loads workspace config correctly from `.please/config.yml`
- [ ] Confirm ARCHITECTURE.md renders correctly on GitHub

## Notes

This is a documentation/setup-only change. No source code or runtime behavior is modified.