### PR TITLE
feat: add team, workspace, and user management commands

### DIFF
--- a/docs/content/en/2.features/5.team-workspace.md
+++ b/docs/content/en/2.features/5.team-workspace.md
@@ -1,0 +1,129 @@
+---
+title: Teams, Workspaces & Users
+description: Manage teams, workspaces, and users with Asana CLI
+---
+
+# Teams, Workspaces & Users
+
+Explore your organization structure: list workspaces, browse teams and their
+members, and look up users with fuzzy search.
+
+## Workspaces
+
+### List Workspaces
+
+```bash
+bun run dev workspace list
+
+# Skip the local cache and fetch fresh data
+bun run dev workspace list --no-cache
+```
+
+Workspace lists are cached locally for 5 minutes (`~/.asana-cli/cache.json`)
+to avoid repeated API calls. Use `--no-cache` when you need live data.
+
+### Get Workspace Details
+
+```bash
+bun run dev workspace get WORKSPACE_ID
+```
+
+### List Workspace Users
+
+```bash
+# Explicit workspace
+bun run dev workspace users WORKSPACE_ID
+
+# Uses the configured default workspace
+bun run dev workspace users
+```
+
+### Set the Default Workspace
+
+Most commands accept `-w/--workspace`; setting a default removes the need to
+pass it every time:
+
+```bash
+bun run dev workspace set-default WORKSPACE_ID
+```
+
+The CLI verifies the workspace is accessible, then saves it to
+`~/.asana-cli/config.json`.
+
+## Teams
+
+Teams are only available in organization workspaces.
+
+### List Teams
+
+```bash
+bun run dev team list --workspace WORKSPACE_ID
+
+# With a default workspace configured
+bun run dev team list
+
+# Bypass the 5-minute team cache
+bun run dev team list --no-cache
+```
+
+### Get Team Details
+
+```bash
+bun run dev team get TEAM_ID
+```
+
+Returns name, description, organization, visibility, and permalink URL.
+
+### List Team Members
+
+```bash
+bun run dev team members TEAM_ID
+```
+
+## Users
+
+### Current User
+
+```bash
+bun run dev user me
+```
+
+### Get a User
+
+Accepts a GID, an email address, or the literal `me`:
+
+```bash
+bun run dev user get 1234567890
+bun run dev user get john@example.com
+bun run dev user get me
+```
+
+### Search Users (Fuzzy)
+
+Searches workspace users by name or email. Matching is case-insensitive and
+ranks exact matches above prefix, substring, and subsequence matches:
+
+```bash
+bun run dev user search "john" --workspace WORKSPACE_ID
+bun run dev user search "john@example.com"
+```
+
+### List a User's Tasks
+
+```bash
+# Incomplete tasks assigned to a user
+bun run dev user tasks USER_ID --workspace WORKSPACE_ID
+
+# Include completed tasks
+bun run dev user tasks me --completed
+```
+
+## Output Formats
+
+All commands honor the global `--format` flag (`toon` by default, plus `json`
+and `plain`):
+
+```bash
+bun run dev workspace list -f json
+bun run dev team members TEAM_ID -f plain
+```

--- a/docs/content/ko/2.features/5.team-workspace.md
+++ b/docs/content/ko/2.features/5.team-workspace.md
@@ -1,0 +1,129 @@
+---
+title: 팀, 워크스페이스 & 사용자
+description: Asana CLI로 팀, 워크스페이스, 사용자를 관리하세요
+---
+
+# 팀, 워크스페이스 & 사용자
+
+조직 구조를 탐색하세요: 워크스페이스 목록 조회, 팀과 팀 멤버 확인,
+퍼지 검색을 통한 사용자 조회를 지원합니다.
+
+## 워크스페이스
+
+### 워크스페이스 목록
+
+```bash
+bun run dev workspace list
+
+# 로컬 캐시를 건너뛰고 최신 데이터 조회
+bun run dev workspace list --no-cache
+```
+
+워크스페이스 목록은 반복적인 API 호출을 줄이기 위해 로컬에 5분간 캐시됩니다
+(`~/.asana-cli/cache.json`). 실시간 데이터가 필요하면 `--no-cache`를 사용하세요.
+
+### 워크스페이스 상세 조회
+
+```bash
+bun run dev workspace get WORKSPACE_ID
+```
+
+### 워크스페이스 사용자 목록
+
+```bash
+# 워크스페이스 명시
+bun run dev workspace users WORKSPACE_ID
+
+# 설정된 기본 워크스페이스 사용
+bun run dev workspace users
+```
+
+### 기본 워크스페이스 설정
+
+대부분의 명령어는 `-w/--workspace` 옵션을 지원합니다. 기본 워크스페이스를
+설정하면 매번 전달할 필요가 없습니다:
+
+```bash
+bun run dev workspace set-default WORKSPACE_ID
+```
+
+CLI가 워크스페이스 접근 가능 여부를 확인한 후
+`~/.asana-cli/config.json`에 저장합니다.
+
+## 팀
+
+팀은 조직(organization) 워크스페이스에서만 사용할 수 있습니다.
+
+### 팀 목록
+
+```bash
+bun run dev team list --workspace WORKSPACE_ID
+
+# 기본 워크스페이스가 설정된 경우
+bun run dev team list
+
+# 5분 팀 캐시 우회
+bun run dev team list --no-cache
+```
+
+### 팀 상세 조회
+
+```bash
+bun run dev team get TEAM_ID
+```
+
+이름, 설명, 조직, 공개 범위, 영구 링크 URL을 반환합니다.
+
+### 팀 멤버 목록
+
+```bash
+bun run dev team members TEAM_ID
+```
+
+## 사용자
+
+### 현재 사용자
+
+```bash
+bun run dev user me
+```
+
+### 사용자 조회
+
+GID, 이메일 주소, 또는 `me` 리터럴을 사용할 수 있습니다:
+
+```bash
+bun run dev user get 1234567890
+bun run dev user get john@example.com
+bun run dev user get me
+```
+
+### 사용자 검색 (퍼지)
+
+이름 또는 이메일로 워크스페이스 사용자를 검색합니다. 대소문자를 구분하지 않으며
+정확 일치 > 접두사 > 부분 문자열 > 부분 수열 순으로 순위를 매깁니다:
+
+```bash
+bun run dev user search "john" --workspace WORKSPACE_ID
+bun run dev user search "john@example.com"
+```
+
+### 사용자의 태스크 목록
+
+```bash
+# 사용자에게 할당된 미완료 태스크
+bun run dev user tasks USER_ID --workspace WORKSPACE_ID
+
+# 완료된 태스크 포함
+bun run dev user tasks me --completed
+```
+
+## 출력 형식
+
+모든 명령어는 전역 `--format` 플래그를 지원합니다 (기본 `toon`, 추가로
+`json`과 `plain`):
+
+```bash
+bun run dev workspace list -f json
+bun run dev team members TEAM_ID -f plain
+```

--- a/src/commands/team.ts
+++ b/src/commands/team.ts
@@ -1,0 +1,123 @@
+import type { TeamListOptions } from '../types'
+import chalk from 'chalk'
+import { Command } from 'commander'
+import { getAsanaClient } from '../lib/asana-client'
+import { getDefaultCache } from '../lib/cache'
+import { loadConfig } from '../lib/config'
+import { handleAsanaError } from '../lib/error-handler'
+import { validateGid, ValidationError } from '../lib/validators'
+import { formatOutput, getOutputFormat } from '../utils/formatter'
+
+const TEAM_LIST_FIELDS = { opt_fields: 'name,description' }
+const MEMBER_FIELDS = { opt_fields: 'name,email' }
+
+export function createTeamCommand(): Command {
+  const team = new Command('team')
+    .description('Manage Asana teams')
+
+  team
+    .command('list')
+    .description('List teams in a workspace')
+    .option('-w, --workspace <workspace>', 'Workspace GID (defaults to configured workspace)')
+    .option('--no-cache', 'Bypass cached team list and fetch fresh data')
+    .action(async (options: TeamListOptions, command: Command) => {
+      const workspace = options.workspace || loadConfig()?.workspace
+      try {
+        if (!workspace) {
+          throw new Error('Workspace is required. Set default workspace or use -w option.')
+        }
+
+        const cache = getDefaultCache()
+        const cacheKey = `teams:${workspace}`
+        const cached = options.cache === false ? null : cache.get<any[]>(cacheKey)
+        let teams: any[]
+
+        if (cached) {
+          teams = cached
+        }
+        else {
+          const client = getAsanaClient()
+          const response = await client.teams.findByWorkspace(workspace, TEAM_LIST_FIELDS)
+          teams = response.data || []
+          cache.set(cacheKey, teams)
+        }
+
+        if (teams.length === 0) {
+          console.log(chalk.yellow('No teams found'))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ teams }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        handleAsanaError(error, 'Team listing', { Workspace: workspace })
+      }
+    })
+
+  team
+    .command('get')
+    .description('Get team details')
+    .argument('<gid>', 'Team GID')
+    .action(async (gid: string, options: any, command: Command) => {
+      try {
+        validateGid(gid, 'Team GID')
+
+        const client = getAsanaClient()
+        const teamDetail = await client.teams.findById(gid, {
+          opt_fields: 'name,description,organization.name,permalink_url,visibility',
+        })
+
+        const teamData = {
+          gid: teamDetail.gid,
+          name: teamDetail.name,
+          description: teamDetail.description,
+          organization: teamDetail.organization?.name,
+          visibility: teamDetail.visibility,
+          permalink_url: teamDetail.permalink_url,
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ team: teamData }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'Team retrieval', { 'Team GID': gid })
+      }
+    })
+
+  team
+    .command('members')
+    .description('List members of a team')
+    .argument('<gid>', 'Team GID')
+    .action(async (gid: string, options: any, command: Command) => {
+      try {
+        validateGid(gid, 'Team GID')
+
+        const client = getAsanaClient()
+        const response = await client.users.findByTeam(gid, MEMBER_FIELDS)
+        const members = response.data || []
+
+        if (members.length === 0) {
+          console.log(chalk.yellow('No members found'))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ members }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'Team member listing', { 'Team GID': gid })
+      }
+    })
+
+  return team
+}

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -27,7 +27,7 @@ function toUserData(user: any) {
     gid: user.gid,
     name: user.name,
     email: user.email,
-    workspaces: (user.workspaces || []).map((ws: any) => ws.name),
+    workspaces: (user.workspaces || []).map((ws: any) => ws?.name).filter(Boolean),
   }
 }
 

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -1,0 +1,149 @@
+import type { UserSearchOptions, UserTasksOptions } from '../types'
+import chalk from 'chalk'
+import { Command } from 'commander'
+import { getAsanaClient } from '../lib/asana-client'
+import { loadConfig } from '../lib/config'
+import { handleAsanaError } from '../lib/error-handler'
+import { validateGid, ValidationError } from '../lib/validators'
+import { formatOutput, getOutputFormat } from '../utils/formatter'
+import { searchUsers } from '../utils/fuzzy'
+
+const USER_DETAIL_FIELDS = { opt_fields: 'name,email,workspaces.name' }
+const USER_LIST_FIELDS = { opt_fields: 'name,email' }
+const TASK_FIELDS = { opt_fields: 'name,completed,due_on' }
+
+/**
+ * Asana accepts a GID, an email address, or the literal "me" as user identifier
+ */
+function validateUserIdentifier(identifier: string): void {
+  if (identifier === 'me' || identifier.includes('@')) {
+    return
+  }
+  validateGid(identifier, 'User GID')
+}
+
+function toUserData(user: any) {
+  return {
+    gid: user.gid,
+    name: user.name,
+    email: user.email,
+    workspaces: (user.workspaces || []).map((ws: any) => ws.name),
+  }
+}
+
+export function createUserCommand(): Command {
+  const user = new Command('user')
+    .description('Manage Asana users')
+
+  user
+    .command('me')
+    .description('Display the current authenticated user')
+    .action(async (options: any, command: Command) => {
+      try {
+        const client = getAsanaClient()
+        const me = await client.users.findById('me', USER_DETAIL_FIELDS)
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ user: toUserData(me) }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        handleAsanaError(error, 'User retrieval', { User: 'me' })
+      }
+    })
+
+  user
+    .command('get')
+    .description('Get user details (GID, email, or "me")')
+    .argument('<user>', 'User GID, email address, or "me"')
+    .action(async (identifier: string, options: any, command: Command) => {
+      try {
+        validateUserIdentifier(identifier)
+
+        const client = getAsanaClient()
+        const userDetail = await client.users.findById(identifier, USER_DETAIL_FIELDS)
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ user: toUserData(userDetail) }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'User retrieval', { User: identifier })
+      }
+    })
+
+  user
+    .command('search')
+    .description('Search workspace users by name or email (fuzzy)')
+    .argument('<query>', 'Name or email to search for')
+    .option('-w, --workspace <workspace>', 'Workspace GID (defaults to configured workspace)')
+    .action(async (query: string, options: UserSearchOptions, command: Command) => {
+      const workspace = options.workspace || loadConfig()?.workspace
+      try {
+        if (!workspace) {
+          throw new Error('Workspace is required. Set default workspace or use -w option.')
+        }
+
+        const client = getAsanaClient()
+        const response = await client.users.findByWorkspace(workspace, USER_LIST_FIELDS)
+        const matches = searchUsers(response.data || [], query)
+
+        if (matches.length === 0) {
+          console.log(chalk.yellow(`No users matching "${query}"`))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ users: matches }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        handleAsanaError(error, 'User search', { Query: query, Workspace: workspace })
+      }
+    })
+
+  user
+    .command('tasks')
+    .description('List tasks assigned to a user')
+    .argument('<user>', 'User GID, email address, or "me"')
+    .option('-w, --workspace <workspace>', 'Workspace GID (defaults to configured workspace)')
+    .option('-c, --completed', 'Include completed tasks')
+    .action(async (identifier: string, options: UserTasksOptions, command: Command) => {
+      const workspace = options.workspace || loadConfig()?.workspace
+      try {
+        validateUserIdentifier(identifier)
+        if (!workspace) {
+          throw new Error('Workspace is required. Set default workspace or use -w option.')
+        }
+
+        const client = getAsanaClient()
+        const response = await client.tasks.findAll({
+          assignee: identifier,
+          workspace,
+          completed_since: options.completed ? undefined : 'now',
+          ...TASK_FIELDS,
+        })
+        const tasks = response.data || []
+
+        if (tasks.length === 0) {
+          console.log(chalk.yellow('No tasks found'))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ tasks }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'User task listing', { User: identifier, Workspace: workspace })
+      }
+    })
+
+  return user
+}

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,0 +1,145 @@
+import type { WorkspaceListOptions } from '../types'
+import chalk from 'chalk'
+import { Command } from 'commander'
+import { getAsanaClient } from '../lib/asana-client'
+import { getDefaultCache } from '../lib/cache'
+import { loadConfig, saveConfig } from '../lib/config'
+import { handleAsanaError } from '../lib/error-handler'
+import { validateGid, ValidationError } from '../lib/validators'
+import { formatOutput, getOutputFormat } from '../utils/formatter'
+
+const WORKSPACES_CACHE_KEY = 'workspaces'
+const USER_FIELDS = { opt_fields: 'name,email' }
+
+export function createWorkspaceCommand(): Command {
+  const workspace = new Command('workspace')
+    .description('Manage Asana workspaces')
+
+  workspace
+    .command('list')
+    .description('List workspaces for the current user')
+    .option('--no-cache', 'Bypass cached workspace list and fetch fresh data')
+    .action(async (options: WorkspaceListOptions, command: Command) => {
+      try {
+        const cache = getDefaultCache()
+        const cached = options.cache === false ? null : cache.get<any[]>(WORKSPACES_CACHE_KEY)
+        let workspaces: any[]
+
+        if (cached) {
+          workspaces = cached
+        }
+        else {
+          const client = getAsanaClient()
+          const response = await client.workspaces.findAll()
+          workspaces = response.data || []
+          cache.set(WORKSPACES_CACHE_KEY, workspaces)
+        }
+
+        if (workspaces.length === 0) {
+          console.log(chalk.yellow('No workspaces found'))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ workspaces }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        handleAsanaError(error, 'Workspace listing', {})
+      }
+    })
+
+  workspace
+    .command('get')
+    .description('Get workspace details')
+    .argument('<gid>', 'Workspace GID')
+    .action(async (gid: string, options: any, command: Command) => {
+      try {
+        validateGid(gid, 'Workspace GID')
+
+        const client = getAsanaClient()
+        const workspaceDetail = await client.workspaces.findById(gid)
+
+        const workspaceData = {
+          gid: workspaceDetail.gid,
+          name: workspaceDetail.name,
+          is_organization: workspaceDetail.is_organization,
+          email_domains: workspaceDetail.email_domains,
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ workspace: workspaceData }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'Workspace retrieval', { 'Workspace GID': gid })
+      }
+    })
+
+  workspace
+    .command('users')
+    .description('List users in a workspace')
+    .argument('[gid]', 'Workspace GID (defaults to configured workspace)')
+    .action(async (gid: string | undefined, options: any, command: Command) => {
+      const workspaceGid = gid || loadConfig()?.workspace
+      try {
+        if (!workspaceGid) {
+          throw new Error('Workspace is required. Set default workspace or pass a workspace GID.')
+        }
+        validateGid(workspaceGid, 'Workspace GID')
+
+        const client = getAsanaClient()
+        const response = await client.workspaces.findUsers(workspaceGid, USER_FIELDS)
+        const users = response.data || []
+
+        if (users.length === 0) {
+          console.log(chalk.yellow('No users found'))
+          return
+        }
+
+        const format = getOutputFormat(command)
+        const output = formatOutput({ users }, { format, colors: process.stdout.isTTY })
+        console.log(output)
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'Workspace user listing', { 'Workspace GID': workspaceGid })
+      }
+    })
+
+  workspace
+    .command('set-default')
+    .description('Set the default workspace in config')
+    .argument('<gid>', 'Workspace GID')
+    .action(async (gid: string) => {
+      try {
+        validateGid(gid, 'Workspace GID')
+
+        const config = loadConfig()
+        if (!config || !config.accessToken) {
+          throw new Error('Not authenticated. Run "asana auth login" first.')
+        }
+
+        // Verify the workspace exists and is accessible before saving
+        const client = getAsanaClient()
+        const workspaceDetail = await client.workspaces.findById(gid)
+
+        saveConfig({ ...config, workspace: gid })
+
+        console.log(chalk.green(`✓ Default workspace set to ${workspaceDetail.name} (${gid})`))
+      }
+      catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
+        handleAsanaError(error, 'Default workspace update', { 'Workspace GID': gid })
+      }
+    })
+
+  return workspace
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ import { createSearchCommand } from './commands/search'
 import { createSectionCommand } from './commands/section'
 import { createSelfUpdateCommand } from './commands/self-update'
 import { createTaskCommand } from './commands/task'
+import { createTeamCommand } from './commands/team'
+import { createUserCommand } from './commands/user'
+import { createWorkspaceCommand } from './commands/workspace'
 
 const program = new Command()
 
@@ -28,6 +31,9 @@ program.addCommand(createProjectCommand())
 program.addCommand(createSectionCommand())
 program.addCommand(createCustomFieldCommand())
 program.addCommand(createSearchCommand())
+program.addCommand(createTeamCommand())
+program.addCommand(createWorkspaceCommand())
+program.addCommand(createUserCommand())
 program.addCommand(createSelfUpdateCommand())
 
 // Parse arguments

--- a/src/lib/asana-client.ts
+++ b/src/lib/asana-client.ts
@@ -11,6 +11,7 @@ let sectionsApiInstance: Asana.SectionsApi | null = null
 let attachmentsApiInstance: Asana.AttachmentsApi | null = null
 let customFieldsApiInstance: Asana.CustomFieldsApi | null = null
 let typeaheadApiInstance: Asana.TypeaheadApi | null = null
+let teamsApiInstance: Asana.TeamsApi | null = null
 
 function initializeApiClient(): typeof Asana.ApiClient.instance {
   if (apiClientInstance) {
@@ -72,6 +73,9 @@ export function getAsanaClient() {
   }
   if (!typeaheadApiInstance) {
     typeaheadApiInstance = new Asana.TypeaheadApi()
+  }
+  if (!teamsApiInstance) {
+    teamsApiInstance = new Asana.TeamsApi()
   }
 
   // Return a wrapper object that matches the old API structure
@@ -266,6 +270,30 @@ export function getAsanaClient() {
         const result = await usersApiInstance!.getUser('me', {})
         return result.data
       },
+      findById: async (userGid: string, opts: Record<string, any> = {}) => {
+        const result = await usersApiInstance!.getUser(userGid, opts)
+        return result.data
+      },
+      // Endpoint is alphabetically sorted and capped at 2000 users by Asana
+      findByWorkspace: async (workspaceGid: string, opts: Record<string, any> = {}) => {
+        const result = await usersApiInstance!.getUsersForWorkspace(workspaceGid, opts)
+        return result
+      },
+      findByTeam: async (teamGid: string, opts: Record<string, any> = {}) => {
+        const result = await usersApiInstance!.getUsersForTeam(teamGid, opts)
+        return result
+      },
+    },
+    teams: {
+      findById: async (teamGid: string, opts: Record<string, any> = {}) => {
+        const result = await teamsApiInstance!.getTeam(teamGid, opts)
+        return result.data
+      },
+      findByWorkspace: async (workspaceGid: string, opts: Record<string, any> = {}) => {
+        const optsWithLimit = { limit: 100, ...opts }
+        const result = await teamsApiInstance!.getTeamsForWorkspace(workspaceGid, optsWithLimit)
+        return result
+      },
     },
     workspaces: {
       findAll: async () => {
@@ -275,6 +303,10 @@ export function getAsanaClient() {
       findById: async (workspaceGid: string) => {
         const result = await workspacesApiInstance!.getWorkspace(workspaceGid, {})
         return result.data
+      },
+      findUsers: async (workspaceGid: string, opts: Record<string, any> = {}) => {
+        const result = await usersApiInstance!.getUsersForWorkspace(workspaceGid, opts)
+        return result
       },
     },
   }
@@ -333,4 +365,5 @@ export function resetClient(): void {
   attachmentsApiInstance = null
   customFieldsApiInstance = null
   typeaheadApiInstance = null
+  teamsApiInstance = null
 }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,77 @@
+/**
+ * File-based cache with TTL for slow-changing Asana data
+ *
+ * Workspace and team lists rarely change, so commands cache them on disk
+ * (~/.asana-cli/cache.json) to avoid repeated API round-trips.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+export const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000
+
+interface CacheEntry {
+  value: unknown
+  expiresAt: number
+}
+
+type CacheStore = Record<string, CacheEntry>
+
+export class FileCache {
+  constructor(
+    private readonly filePath: string,
+    private readonly defaultTtlMs: number = DEFAULT_CACHE_TTL_MS,
+  ) {}
+
+  get<T>(key: string): T | null {
+    const entry = this.load()[key]
+
+    if (!entry || Date.now() >= entry.expiresAt) {
+      return null
+    }
+
+    return entry.value as T
+  }
+
+  set(key: string, value: unknown, ttlMs: number = this.defaultTtlMs): void {
+    const store = this.load()
+    store[key] = { value, expiresAt: Date.now() + ttlMs }
+    this.persist(store)
+  }
+
+  clear(): void {
+    this.persist({})
+  }
+
+  private load(): CacheStore {
+    if (!existsSync(this.filePath)) {
+      return {}
+    }
+
+    try {
+      return JSON.parse(readFileSync(this.filePath, 'utf-8'))
+    }
+    catch {
+      // Corrupt cache is not fatal; behave as if empty and let set() rewrite it
+      return {}
+    }
+  }
+
+  private persist(store: CacheStore): void {
+    const dir = dirname(this.filePath)
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+    writeFileSync(this.filePath, JSON.stringify(store))
+  }
+}
+
+let defaultCacheInstance: FileCache | null = null
+
+export function getDefaultCache(): FileCache {
+  if (!defaultCacheInstance) {
+    defaultCacheInstance = new FileCache(join(homedir(), '.asana-cli', 'cache.json'))
+  }
+  return defaultCacheInstance
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -59,11 +59,17 @@ export class FileCache {
   }
 
   private persist(store: CacheStore): void {
-    const dir = dirname(this.filePath)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
+    try {
+      const dir = dirname(this.filePath)
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true })
+      }
+      writeFileSync(this.filePath, JSON.stringify(store))
     }
-    writeFileSync(this.filePath, JSON.stringify(store))
+    catch {
+      // Cache is a performance optimization; a failed write (permissions,
+      // full disk) must never fail the command that triggered it
+    }
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,6 +71,24 @@ export interface ProjectUpdateOptions {
   public?: boolean | string
 }
 
+export interface TeamListOptions {
+  workspace?: string
+  cache?: boolean // Commander sets false when --no-cache is passed
+}
+
+export interface WorkspaceListOptions {
+  cache?: boolean
+}
+
+export interface UserSearchOptions {
+  workspace?: string
+}
+
+export interface UserTasksOptions {
+  workspace?: string
+  completed?: boolean
+}
+
 export interface SectionCreateOptions {
   name: string
   insertBefore?: string

--- a/src/utils/fuzzy.ts
+++ b/src/utils/fuzzy.ts
@@ -1,0 +1,71 @@
+/**
+ * Lightweight fuzzy matching for user search
+ *
+ * Scoring tiers (higher wins): exact match > prefix > substring > subsequence.
+ * Within the subsequence tier, shorter targets score slightly higher so the
+ * closest match sorts first.
+ */
+
+const SCORE_EXACT = 1000
+const SCORE_PREFIX = 750
+const SCORE_SUBSTRING = 500
+const SCORE_SUBSEQUENCE = 250
+
+export interface SearchableUser {
+  gid: string
+  name?: string
+  email?: string
+}
+
+export function fuzzyScore(query: string, text: string): number {
+  const q = query.trim().toLowerCase()
+  const t = text.toLowerCase()
+
+  if (!q || !t) {
+    return 0
+  }
+  if (t === q) {
+    return SCORE_EXACT
+  }
+  if (t.startsWith(q)) {
+    return SCORE_PREFIX
+  }
+  if (t.includes(q)) {
+    return SCORE_SUBSTRING
+  }
+  if (isSubsequence(q, t)) {
+    // Prefer tighter targets among subsequence matches
+    return SCORE_SUBSEQUENCE - Math.min(t.length - q.length, SCORE_SUBSEQUENCE - 1)
+  }
+  return 0
+}
+
+function isSubsequence(query: string, text: string): boolean {
+  let index = 0
+  for (const char of text) {
+    if (char === query[index]) {
+      index++
+    }
+    if (index === query.length) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Search users by name or email, sorted by best match first
+ */
+export function searchUsers<T extends SearchableUser>(users: T[], query: string): T[] {
+  return users
+    .map(user => ({
+      user,
+      score: Math.max(
+        fuzzyScore(query, user.name ?? ''),
+        fuzzyScore(query, user.email ?? ''),
+      ),
+    }))
+    .filter(entry => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map(entry => entry.user)
+}

--- a/test/commands/team.test.ts
+++ b/test/commands/team.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test'
+import { createTeamCommand } from '../../src/commands/team'
+
+describe('team command', () => {
+  describe('command structure', () => {
+    test('creates command with correct name', () => {
+      const teamCommand = createTeamCommand()
+
+      expect(teamCommand.name()).toBe('team')
+    })
+
+    test('creates command with correct description', () => {
+      const teamCommand = createTeamCommand()
+
+      expect(teamCommand.description()).toBe('Manage Asana teams')
+    })
+
+    test('has all required subcommands', () => {
+      const teamCommand = createTeamCommand()
+      const commandNames = teamCommand.commands.map(cmd => cmd.name())
+
+      expect(commandNames).toContain('list')
+      expect(commandNames).toContain('get')
+      expect(commandNames).toContain('members')
+    })
+  })
+
+  describe('list command', () => {
+    test('has correct description', () => {
+      const teamCommand = createTeamCommand()
+      const listCommand = teamCommand.commands.find(cmd => cmd.name() === 'list')
+
+      expect(listCommand?.description()).toBe('List teams in a workspace')
+    })
+
+    test('has optional workspace option', () => {
+      const teamCommand = createTeamCommand()
+      const listCommand = teamCommand.commands.find(cmd => cmd.name() === 'list')
+      const workspaceOption = listCommand?.options.find(opt => opt.long === '--workspace')
+
+      expect(workspaceOption).toBeDefined()
+      expect(workspaceOption?.mandatory).toBe(false)
+    })
+
+    test('has no-cache flag to bypass cached data', () => {
+      const teamCommand = createTeamCommand()
+      const listCommand = teamCommand.commands.find(cmd => cmd.name() === 'list')
+      const cacheOption = listCommand?.options.find(opt => opt.long === '--no-cache')
+
+      expect(cacheOption).toBeDefined()
+    })
+  })
+
+  describe('get command', () => {
+    test('has correct description', () => {
+      const teamCommand = createTeamCommand()
+      const getCommand = teamCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.description()).toBe('Get team details')
+    })
+
+    test('requires team gid argument', () => {
+      const teamCommand = createTeamCommand()
+      const getCommand = teamCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+  })
+
+  describe('members command', () => {
+    test('has correct description', () => {
+      const teamCommand = createTeamCommand()
+      const membersCommand = teamCommand.commands.find(cmd => cmd.name() === 'members')
+
+      expect(membersCommand?.description()).toBe('List members of a team')
+    })
+
+    test('requires team gid argument', () => {
+      const teamCommand = createTeamCommand()
+      const membersCommand = teamCommand.commands.find(cmd => cmd.name() === 'members')
+
+      expect(membersCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+  })
+})

--- a/test/commands/user.test.ts
+++ b/test/commands/user.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'bun:test'
+import { createUserCommand } from '../../src/commands/user'
+
+describe('user command', () => {
+  describe('command structure', () => {
+    test('creates command with correct name', () => {
+      const userCommand = createUserCommand()
+
+      expect(userCommand.name()).toBe('user')
+    })
+
+    test('creates command with correct description', () => {
+      const userCommand = createUserCommand()
+
+      expect(userCommand.description()).toBe('Manage Asana users')
+    })
+
+    test('has all required subcommands', () => {
+      const userCommand = createUserCommand()
+      const commandNames = userCommand.commands.map(cmd => cmd.name())
+
+      expect(commandNames).toContain('me')
+      expect(commandNames).toContain('get')
+      expect(commandNames).toContain('search')
+      expect(commandNames).toContain('tasks')
+    })
+  })
+
+  describe('me command', () => {
+    test('has correct description', () => {
+      const userCommand = createUserCommand()
+      const meCommand = userCommand.commands.find(cmd => cmd.name() === 'me')
+
+      expect(meCommand?.description()).toBe('Display the current authenticated user')
+    })
+  })
+
+  describe('get command', () => {
+    test('has correct description', () => {
+      const userCommand = createUserCommand()
+      const getCommand = userCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.description()).toBe('Get user details (GID, email, or "me")')
+    })
+
+    test('requires user identifier argument', () => {
+      const userCommand = createUserCommand()
+      const getCommand = userCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+  })
+
+  describe('search command', () => {
+    test('has correct description', () => {
+      const userCommand = createUserCommand()
+      const searchCommand = userCommand.commands.find(cmd => cmd.name() === 'search')
+
+      expect(searchCommand?.description()).toBe('Search workspace users by name or email (fuzzy)')
+    })
+
+    test('requires query argument', () => {
+      const userCommand = createUserCommand()
+      const searchCommand = userCommand.commands.find(cmd => cmd.name() === 'search')
+
+      expect(searchCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+
+    test('has optional workspace option', () => {
+      const userCommand = createUserCommand()
+      const searchCommand = userCommand.commands.find(cmd => cmd.name() === 'search')
+      const workspaceOption = searchCommand?.options.find(opt => opt.long === '--workspace')
+
+      expect(workspaceOption).toBeDefined()
+      expect(workspaceOption?.mandatory).toBe(false)
+    })
+  })
+
+  describe('tasks command', () => {
+    test('has correct description', () => {
+      const userCommand = createUserCommand()
+      const tasksCommand = userCommand.commands.find(cmd => cmd.name() === 'tasks')
+
+      expect(tasksCommand?.description()).toBe('List tasks assigned to a user')
+    })
+
+    test('requires user identifier argument', () => {
+      const userCommand = createUserCommand()
+      const tasksCommand = userCommand.commands.find(cmd => cmd.name() === 'tasks')
+
+      expect(tasksCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+
+    test('has optional workspace option', () => {
+      const userCommand = createUserCommand()
+      const tasksCommand = userCommand.commands.find(cmd => cmd.name() === 'tasks')
+      const workspaceOption = tasksCommand?.options.find(opt => opt.long === '--workspace')
+
+      expect(workspaceOption).toBeDefined()
+    })
+
+    test('has completed flag', () => {
+      const userCommand = createUserCommand()
+      const tasksCommand = userCommand.commands.find(cmd => cmd.name() === 'tasks')
+      const completedOption = tasksCommand?.options.find(opt => opt.long === '--completed')
+
+      expect(completedOption).toBeDefined()
+    })
+  })
+})

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { createWorkspaceCommand } from '../../src/commands/workspace'
+
+describe('workspace command', () => {
+  describe('command structure', () => {
+    test('creates command with correct name', () => {
+      const workspaceCommand = createWorkspaceCommand()
+
+      expect(workspaceCommand.name()).toBe('workspace')
+    })
+
+    test('creates command with correct description', () => {
+      const workspaceCommand = createWorkspaceCommand()
+
+      expect(workspaceCommand.description()).toBe('Manage Asana workspaces')
+    })
+
+    test('has all required subcommands', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const commandNames = workspaceCommand.commands.map(cmd => cmd.name())
+
+      expect(commandNames).toContain('list')
+      expect(commandNames).toContain('get')
+      expect(commandNames).toContain('users')
+      expect(commandNames).toContain('set-default')
+    })
+  })
+
+  describe('list command', () => {
+    test('has correct description', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const listCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'list')
+
+      expect(listCommand?.description()).toBe('List workspaces for the current user')
+    })
+
+    test('has no-cache flag to bypass cached data', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const listCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'list')
+      const cacheOption = listCommand?.options.find(opt => opt.long === '--no-cache')
+
+      expect(cacheOption).toBeDefined()
+    })
+  })
+
+  describe('get command', () => {
+    test('has correct description', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const getCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.description()).toBe('Get workspace details')
+    })
+
+    test('requires workspace gid argument', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const getCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'get')
+
+      expect(getCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+  })
+
+  describe('users command', () => {
+    test('has correct description', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const usersCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'users')
+
+      expect(usersCommand?.description()).toBe('List users in a workspace')
+    })
+
+    test('has optional workspace gid argument falling back to default', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const usersCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'users')
+
+      expect(usersCommand?.registeredArguments[0]?.required).toBe(false)
+    })
+  })
+
+  describe('set-default command', () => {
+    test('has correct description', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const setDefaultCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'set-default')
+
+      expect(setDefaultCommand?.description()).toBe('Set the default workspace in config')
+    })
+
+    test('requires workspace gid argument', () => {
+      const workspaceCommand = createWorkspaceCommand()
+      const setDefaultCommand = workspaceCommand.commands.find(cmd => cmd.name() === 'set-default')
+
+      expect(setDefaultCommand?.registeredArguments[0]?.required).toBe(true)
+    })
+  })
+})

--- a/test/lib/cache.test.ts
+++ b/test/lib/cache.test.ts
@@ -73,6 +73,17 @@ describe('FileCache', () => {
     })
   })
 
+  describe('unwritable cache file', () => {
+    test('should not throw when the cache path cannot be written', () => {
+      // A directory at the cache file path makes writeFileSync fail
+      const unwritablePath = cacheDir
+      const cache = new FileCache(unwritablePath)
+
+      expect(() => cache.set('key', 'value')).not.toThrow()
+      expect(cache.get('key')).toBeNull()
+    })
+  })
+
   describe('corrupt cache file', () => {
     test('should treat unreadable JSON as empty cache', () => {
       writeFileSync(cacheFile, 'not-json{{{')

--- a/test/lib/cache.test.ts
+++ b/test/lib/cache.test.ts
@@ -1,0 +1,94 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { DEFAULT_CACHE_TTL_MS, FileCache } from '../../src/lib/cache'
+
+describe('FileCache', () => {
+  let cacheDir: string
+  let cacheFile: string
+
+  beforeEach(() => {
+    cacheDir = mkdtempSync(join(tmpdir(), 'asana-cli-cache-'))
+    cacheFile = join(cacheDir, 'cache.json')
+  })
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true })
+  })
+
+  describe('get and set', () => {
+    test('should return null for missing key', () => {
+      const cache = new FileCache(cacheFile)
+
+      expect(cache.get('missing')).toBeNull()
+    })
+
+    test('should return stored value before TTL expires', () => {
+      const cache = new FileCache(cacheFile)
+
+      cache.set('workspaces', [{ gid: '1', name: 'Acme' }])
+
+      expect(cache.get('workspaces')).toEqual([{ gid: '1', name: 'Acme' }])
+    })
+
+    test('should persist values across instances', () => {
+      const writer = new FileCache(cacheFile)
+      writer.set('teams:42', [{ gid: '7', name: 'Platform' }])
+
+      const reader = new FileCache(cacheFile)
+
+      expect(reader.get('teams:42')).toEqual([{ gid: '7', name: 'Platform' }])
+    })
+
+    test('should return null after TTL expires', () => {
+      const cache = new FileCache(cacheFile, -1)
+
+      cache.set('workspaces', [{ gid: '1' }])
+
+      expect(cache.get('workspaces')).toBeNull()
+    })
+
+    test('should use per-entry TTL over default TTL', () => {
+      const cache = new FileCache(cacheFile, DEFAULT_CACHE_TTL_MS)
+
+      cache.set('expired', 'value', -1)
+      cache.set('fresh', 'value')
+
+      expect(cache.get('expired')).toBeNull()
+      expect(cache.get('fresh')).toBe('value')
+    })
+  })
+
+  describe('clear', () => {
+    test('should remove all entries', () => {
+      const cache = new FileCache(cacheFile)
+      cache.set('a', 1)
+      cache.set('b', 2)
+
+      cache.clear()
+
+      expect(cache.get('a')).toBeNull()
+      expect(cache.get('b')).toBeNull()
+    })
+  })
+
+  describe('corrupt cache file', () => {
+    test('should treat unreadable JSON as empty cache', () => {
+      writeFileSync(cacheFile, 'not-json{{{')
+      const cache = new FileCache(cacheFile)
+
+      expect(cache.get('anything')).toBeNull()
+    })
+
+    test('should recover by overwriting corrupt file on set', () => {
+      writeFileSync(cacheFile, 'not-json{{{')
+      const cache = new FileCache(cacheFile)
+
+      cache.set('key', 'value')
+
+      expect(cache.get('key')).toBe('value')
+      expect(existsSync(cacheFile)).toBe(true)
+    })
+  })
+})

--- a/test/utils/fuzzy.test.ts
+++ b/test/utils/fuzzy.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test'
+import { fuzzyScore, searchUsers } from '../../src/utils/fuzzy'
+
+describe('fuzzyScore', () => {
+  test('should give highest score to exact match', () => {
+    expect(fuzzyScore('john', 'john')).toBeGreaterThan(fuzzyScore('john', 'johnny'))
+  })
+
+  test('should score substring match higher than subsequence match', () => {
+    const substring = fuzzyScore('ohn', 'john doe')
+    const subsequence = fuzzyScore('jde', 'john doe')
+
+    expect(substring).toBeGreaterThan(subsequence)
+  })
+
+  test('should match case-insensitively', () => {
+    expect(fuzzyScore('JOHN', 'john@example.com')).toBeGreaterThan(0)
+  })
+
+  test('should return 0 when characters are not a subsequence', () => {
+    expect(fuzzyScore('xyz', 'john doe')).toBe(0)
+  })
+
+  test('should return 0 for empty query', () => {
+    expect(fuzzyScore('', 'john')).toBe(0)
+  })
+})
+
+describe('searchUsers', () => {
+  const users = [
+    { gid: '1', name: 'John Doe', email: 'john@example.com' },
+    { gid: '2', name: 'Jane Smith', email: 'jane@example.com' },
+    { gid: '3', name: 'Bob Johnson', email: 'bob@example.com' },
+  ]
+
+  test('should find user by exact email', () => {
+    const results = searchUsers(users, 'john@example.com')
+
+    expect(results[0]?.gid).toBe('1')
+  })
+
+  test('should find users by partial name', () => {
+    const results = searchUsers(users, 'john')
+    const gids = results.map(user => user.gid)
+
+    expect(gids).toContain('1')
+    expect(gids).toContain('3')
+  })
+
+  test('should rank exact name match above partial match', () => {
+    const results = searchUsers(users, 'john doe')
+
+    expect(results[0]?.gid).toBe('1')
+  })
+
+  test('should return empty array when nothing matches', () => {
+    expect(searchUsers(users, 'zzzzz')).toEqual([])
+  })
+
+  test('should handle users without email', () => {
+    const noEmail = [{ gid: '9', name: 'Solo Name' }]
+
+    expect(searchUsers(noEmail, 'solo')[0]?.gid).toBe('9')
+  })
+})

--- a/tests/e2e/team-workspace-user.test.ts
+++ b/tests/e2e/team-workspace-user.test.ts
@@ -1,0 +1,132 @@
+import { $ } from 'bun'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanupTestEnvironment, setupTestEnvironment } from './helpers'
+
+describe('Team, Workspace & User E2E Tests', () => {
+  let workspace: string
+  let client: any
+
+  beforeAll(() => {
+    const env = setupTestEnvironment()
+    workspace = env.workspace
+    client = env.client
+  })
+
+  afterAll(() => {
+    cleanupTestEnvironment()
+  })
+
+  describe('Workspace Commands', () => {
+    test('should list workspaces including the test workspace', async () => {
+      const result = await $`bun run src/index.ts workspace list --no-cache -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.workspaces).toBeDefined()
+      const gids = parsed.workspaces.map((ws: any) => ws.gid)
+      expect(gids).toContain(workspace)
+    })
+
+    test('should serve workspace list from cache on second call', async () => {
+      await $`bun run src/index.ts workspace list --no-cache -f json`.text()
+      const cachedResult = await $`bun run src/index.ts workspace list -f json`.text()
+
+      const parsed = JSON.parse(cachedResult)
+      expect(parsed.workspaces.map((ws: any) => ws.gid)).toContain(workspace)
+    })
+
+    test('should get workspace details', async () => {
+      const result = await $`bun run src/index.ts workspace get ${workspace} -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.workspace.gid).toBe(workspace)
+      expect(parsed.workspace.name).toBeDefined()
+    })
+
+    test('should list workspace users', async () => {
+      const result = await $`bun run src/index.ts workspace users ${workspace} -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.users.length).toBeGreaterThan(0)
+      expect(parsed.users[0].gid).toBeDefined()
+    })
+
+    test('should fail with invalid workspace gid', async () => {
+      try {
+        await $`bun run src/index.ts workspace get not-a-gid`.quiet()
+        expect(true).toBe(false) // Should have failed
+      }
+      catch (error: any) {
+        expect(error.exitCode).not.toBe(0)
+      }
+    })
+  })
+
+  describe('Team Commands', () => {
+    test('should list teams or report workspace is not an organization', async () => {
+      try {
+        const result = await $`bun run src/index.ts team list -w ${workspace} --no-cache -f json`.text()
+        const hasTeamsOrEmpty = result.includes('"teams"') || result.includes('No teams found')
+        expect(hasTeamsOrEmpty).toBe(true)
+      }
+      catch (error: any) {
+        // Personal (non-organization) workspaces cannot list teams
+        expect(error.exitCode).not.toBe(0)
+      }
+    })
+
+    test('should fail with invalid team gid', async () => {
+      try {
+        await $`bun run src/index.ts team get not-a-gid`.quiet()
+        expect(true).toBe(false) // Should have failed
+      }
+      catch (error: any) {
+        expect(error.exitCode).not.toBe(0)
+      }
+    })
+  })
+
+  describe('User Commands', () => {
+    test('should display current user with workspaces', async () => {
+      const result = await $`bun run src/index.ts user me -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.user.gid).toBeDefined()
+      expect(parsed.user.name).toBeDefined()
+    })
+
+    test('should get user by gid', async () => {
+      const me = await client.users.me()
+
+      const result = await $`bun run src/index.ts user get ${me.gid} -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.user.gid).toBe(me.gid)
+    })
+
+    test('should find current user via fuzzy search', async () => {
+      const me = await client.users.findById('me', { opt_fields: 'name,email' })
+
+      const result = await $`bun run src/index.ts user search ${me.name} -w ${workspace} -f json`.text()
+
+      const parsed = JSON.parse(result)
+      expect(parsed.users.map((user: any) => user.gid)).toContain(me.gid)
+    })
+
+    test('should list tasks assigned to me', async () => {
+      const result = await $`bun run src/index.ts user tasks me -w ${workspace} -f json`.text()
+
+      const hasTasksOrEmpty = result.includes('"tasks"') || result.includes('No tasks found')
+      expect(hasTasksOrEmpty).toBe(true)
+    })
+
+    test('should fail with invalid user gid', async () => {
+      try {
+        await $`bun run src/index.ts user get not!a!gid`.quiet()
+        expect(true).toBe(false) // Should have failed
+      }
+      catch (error: any) {
+        expect(error.exitCode).not.toBe(0)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements Phase 5: Team & Workspace Management (#18).

### New Commands

| Command | Description |
| --- | --- |
| `asana team list [-w] [--no-cache]` | List teams in a workspace (cached 5 min) |
| `asana team get <gid>` | Get team details |
| `asana team members <gid>` | List team members |
| `asana workspace list [--no-cache]` | List workspaces (cached 5 min) |
| `asana workspace get <gid>` | Get workspace details |
| `asana workspace users [gid]` | Workspace user directory (falls back to default workspace) |
| `asana workspace set-default <gid>` | Persist default workspace to `~/.asana-cli/config.json` |
| `asana user me` | Current authenticated user |
| `asana user get <gid\|email\|me>` | User lookup |
| `asana user search <query> [-w]` | Fuzzy user search by name/email |
| `asana user tasks <user> [-w] [-c]` | Tasks assigned to a user |

### Implementation Notes

- **Caching**: new `FileCache` (`src/lib/cache.ts`) — TTL-based JSON file cache at `~/.asana-cli/cache.json`, 5-minute default TTL, corrupt-file safe. Used by `workspace list` and `team list`; `--no-cache` bypasses it.
- **Fuzzy search**: `src/utils/fuzzy.ts` with tiered scoring (exact > prefix > substring > subsequence), case-insensitive, matches name or email.
- **SDK wrappers**: extended `asana-client.ts` with `TeamsApi` (`getTeam`, `getTeamsForWorkspace`) and `UsersApi` (`getUser`, `getUsersForWorkspace`, `getUsersForTeam`). `getUsersForWorkspace`/`getUsersForTeam` intentionally omit `limit` (endpoint is unpaginated, capped at 2000 by Asana).
- **Default workspace**: all workspace-scoped commands fall back to `config.workspace`; `workspace set-default` verifies accessibility before saving.
- CHANGELOG.md is managed by release-please, so no manual edit; conventional commits will drive the next release notes.

## Deliverables (from #18)

- [x] Create `src/commands/team.ts`
- [x] Enhance workspace commands (`src/commands/workspace.ts`: list/get/users/set-default)
- [x] Implement user commands (`src/commands/user.ts`)
- [x] Add workspace data caching (`src/lib/cache.ts`)
- [x] Config support for default workspace (`workspace set-default`)
- [x] Unit tests for all commands (44 new tests; suite: 244 pass)
- [x] E2E tests for team workflows (`tests/e2e/team-workspace-user.test.ts`)
- [x] Documentation (`docs/content/{en,ko}/2.features/5.team-workspace.md`)
- [x] CHANGELOG via release-please (conventional commits)

## Test Plan

- [x] `bun test test/` — 244 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run build` + smoke test of `team/workspace/user --help` and invalid-GID failure paths (exit 1)
- [ ] `bun run test:e2e` — requires `ASANA_ACCESS_TOKEN`/`ASANA_WORKSPACE` (encrypted `.env`; run via the manual E2E workflow)

Closes #18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds team, workspace, and user management commands to the Asana CLI with caching, fuzzy search, and default workspace support. Implements Phase 5 from #18 and reduces repeated API calls.

- New Features
  - Team: `asana team list [-w] [--no-cache]`, `asana team get <gid>`, `asana team members <gid>` (team list cached 5 min).
  - Workspace: `asana workspace list [--no-cache]`, `asana workspace get <gid>`, `asana workspace users [gid]`, `asana workspace set-default <gid>` (persists to `~/.asana-cli/config.json`; other commands fall back to it).
  - User: `asana user me`, `asana user get <gid|email|me>`, `asana user search <query> [-w]` (fuzzy by name/email), `asana user tasks <user> [-w] [-c]` (robust to null workspaces in profile data).
  - Caching: `FileCache` stores JSON at `~/.asana-cli/cache.json` with a 5‑minute TTL; `--no-cache` bypasses it; writes are fail‑safe (persist errors never break commands).
  - Client: wrappers for `users` (`me`, `findById`, `findByWorkspace`, `findByTeam`), `teams` (`findById`, `findByWorkspace`), and `workspaces.findUsers`; team listing requests use a limit of 100.
  - Docs/Tests: guides added (EN/KR); unit tests cover commands, `FileCache`, and fuzzy search; E2E suite for team/workspace/user flows; regression test ensures unwritable cache paths don’t throw.

<sup>Written for commit 806c03e18cf1bc8e1d26a09eb1935c8205799848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

