### PR TITLE
chore: enable skill-optimizer plugin in project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,8 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "enabledPlugins": {
+    "skill-optimizer@pleaseai": true
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,7 @@
     "ask": []
   },
   "enabledPlugins": {
-    "skill-optimizer@pleaseai": true
+    "skill-optimizer@pleaseai": true,
+    "bun@pleaseai": true
   }
 }


### PR DESCRIPTION
## Summary

- `.claude/settings.json`에 `enabledPlugins` 항목을 추가하여 `skill-optimizer@pleaseai` 플러그인을 프로젝트 수준에서 활성화합니다.

## Changes

- `.claude/settings.json`: `enabledPlugins.skill-optimizer@pleaseai = true` 추가

## Test plan

- 설정 파일 변경만 포함된 chore이며 코드 동작 변화 없음
- `/reload-plugins` 후 skill-optimizer 스킬이 활성화되는지 확인

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `skill-optimizer@pleaseai` and `bun@pleaseai` plugins at the project level by adding them under `enabledPlugins` in `.claude/settings.json`. This makes both plugins available across the project with no runtime code changes.

- **Migration**
  - Run `/reload-plugins` to load the plugins after merge.

<sup>Written for commit f984c5ca090bbf1d6dad752354472f081ee71273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an `enabledPlugins` configuration to control which plugins are active.
  * Enabled `skill-optimizer@pleaseai` and `bun@pleaseai` while leaving existing permissions unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->