### PR TITLE
fix(task): apply due date on `task create` via --due-on

### DIFF
--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -26,7 +26,8 @@ export function createTaskCommand(): Command {
     .requiredOption('-n, --name <name>', 'Task name')
     .option('-d, --notes <notes>', 'Task description/notes')
     .option('-a, --assignee <assignee>', 'Assignee user GID')
-    .option('--due <date>', 'Due date (YYYY-MM-DD)')
+    .option('--due-on <date>', 'Due date (YYYY-MM-DD)')
+    .option('--due <date>', 'Deprecated alias for --due-on (YYYY-MM-DD)')
     .option('-w, --workspace <workspace>', 'Workspace GID')
     .option('-p, --project <project>', 'Project GID')
     .action(async (options: TaskOptions, command: Command) => {
@@ -50,8 +51,14 @@ export function createTaskCommand(): Command {
           taskData.notes = options.notes
         if (options.assignee)
           taskData.assignee = options.assignee
-        if (options.dueOn)
-          taskData.due_on = options.dueOn
+        // Accept both --due-on (canonical, matches `task update`) and the
+        // deprecated --due alias. Previously the option was --due but the code
+        // only read options.dueOn, so the due date was silently dropped.
+        const dueOn = options.dueOn ?? options.due
+        if (dueOn) {
+          validateDateFormat(dueOn, options.dueOn ? '--due-on' : '--due')
+          taskData.due_on = dueOn
+        }
         if (options.project)
           taskData.projects = [options.project]
 

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -80,6 +80,9 @@ export function createTaskCommand(): Command {
         console.log(output)
       }
       catch (error) {
+        if (error instanceof ValidationError) {
+          process.exit(1)
+        }
         handleAsanaError(error, 'Task creation', {
           'Task name': options.name,
           'Workspace': workspace,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export interface TaskOptions {
   notes?: string
   assignee?: string
   dueOn?: string
+  /** Deprecated alias for `dueOn`, kept for backward compatibility with `--due`. */
+  due?: string
   workspace?: string
   project?: string
 }

--- a/test/commands/task-create-due.test.ts
+++ b/test/commands/task-create-due.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+
+/**
+ * Regression test for `task create` due date handling.
+ *
+ * The create command exposed `--due` but the action only read `options.dueOn`,
+ * so the due date was silently dropped (the API received no `due_on`). This
+ * verifies the canonical `--due-on` flag and the legacy `--due` alias both
+ * reach the API as `due_on`. The asana client and config are mocked, so no
+ * network or disk is touched.
+ */
+describe('task create due date', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  async function runCreate(args: string[]): Promise<any> {
+    let captured: any = null
+    mock.module('../../src/lib/asana-client', () => ({
+      getAsanaClient: () => ({
+        tasks: {
+          create: async (taskData: any) => {
+            captured = taskData
+            return { gid: '1', name: taskData.name, permalink_url: 'https://app.asana.com/x' }
+          },
+        },
+      }),
+    }))
+    mock.module('../../src/lib/config', () => ({
+      loadConfig: () => ({ workspace: '123' }),
+    }))
+
+    const { createTaskCommand } = await import('../../src/commands/task')
+    const task = createTaskCommand()
+    await task.parseAsync(['create', ...args], { from: 'user' })
+    return captured
+  }
+
+  test('--due-on sets due_on on the created task', async () => {
+    const taskData = await runCreate(['-n', 'Task', '-w', '123', '--due-on', '2026-06-26'])
+    expect(taskData?.due_on).toBe('2026-06-26')
+  })
+
+  test('legacy --due alias also sets due_on', async () => {
+    const taskData = await runCreate(['-n', 'Task', '-w', '123', '--due', '2026-06-26'])
+    expect(taskData?.due_on).toBe('2026-06-26')
+  })
+})

--- a/test/commands/task-create-due.test.ts
+++ b/test/commands/task-create-due.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 
 /**
  * Regression test for `task create` due date handling.
@@ -44,5 +44,27 @@ describe('task create due date', () => {
   test('legacy --due alias also sets due_on', async () => {
     const taskData = await runCreate(['-n', 'Task', '-w', '123', '--due', '2026-06-26'])
     expect(taskData?.due_on).toBe('2026-06-26')
+  })
+
+  test('invalid date format exits without calling the API', async () => {
+    // validateDateFormat throws a ValidationError, which the create action
+    // catches and turns into process.exit(1) (consistent with sibling
+    // commands). Stub process.exit to throw so the action stops here instead
+    // of terminating the test runner, and silence the validation output
+    // written to stderr.
+    const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit called')
+    }) as never)
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await expect(
+        runCreate(['-n', 'Task', '-w', '123', '--due-on', 'invalid-date']),
+      ).rejects.toThrow('process.exit called')
+      expect(exitSpy).toHaveBeenCalledWith(1)
+    }
+    finally {
+      exitSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Problem

`asana task create --due 2026-06-26` silently ignores the due date — created
tasks come back with `due_on: null`. The command defined `--due`, which
commander stores as `options.due`, but the action only read `options.dueOn`:

```ts
.option('--due <date>', 'Due date (YYYY-MM-DD)')
...
if (options.dueOn)            // always undefined for `--due`
  taskData.due_on = options.dueOn
```

`task update` and `task subtask create` already use `--due-on`, so `task create`
was both inconsistent and broken.

## Fix

- Add the canonical `--due-on` flag (matches the sibling commands).
- Keep `--due` as a working **deprecated alias** so existing scripts that passed
  `--due` (and were silently no-ops) now actually set the due date.
- Validate the date and map either flag to `due_on`.

## Test

`test/commands/task-create-due.test.ts` mocks the asana client + config (no
network/disk) and asserts that both `--due-on` and the legacy `--due` reach the
API as `due_on`. Fails against the old code, passes with the fix.

## Verification

Confirmed against the live API: `--due-on` and `--due` both set `due_on`
correctly; an out-of-range date is rejected. `bun run lint` and the full task
test suite pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `task create` so due dates are applied. Adds `--due-on`, keeps `--due` as a deprecated alias, validates the date, and handles invalid dates consistently.

- **Bug Fixes**
  - Apply `due_on` when using `--due-on` or legacy `--due` (consistent with `task update` and `task subtask create`).
  - Validate date format; on invalid input, exit with code 1 without duplicate error output.
  - Add regression tests for both flags and a sad-path test for invalid dates.

- **Migration**
  - Switch scripts to `--due-on`; `--due` remains as a deprecated alias.

<sup>Written for commit 7e5431bb10bc15fb98280a98731830fc44b953dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restored compatibility for `task create --due` while standardizing on `--due-on`; both correctly set the task due date when provided.
  * Due-date validation now fails with exit code `1` for validation errors.

* **Tests**
  * Added/expanded Bun tests covering `--due-on` and legacy `--due` behavior, including regression coverage for invalid due-date formats and exit-code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->