### PR TITLE
fix(task): honor global --format in `task list`

### DIFF
--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -6,7 +6,7 @@ import { getAsanaClient } from '../lib/asana-client'
 import { loadConfig } from '../lib/config'
 import { handleAsanaError } from '../lib/error-handler'
 import { validateDateFormat, validateGid, validateUpdateFields, ValidationError } from '../lib/validators'
-import { formatOutput } from '../utils/formatter'
+import { formatOutput, getOutputFormat } from '../utils/formatter'
 import { createTaskCustomFieldCommand } from './custom-field'
 import { createAttachCommand, createAttachmentCommand } from './task-attachment'
 import { createBatchCreateCommand, createBatchDeleteCommand, createBatchUpdateCommand } from './task-batch'
@@ -138,8 +138,11 @@ export function createTaskCommand(): Command {
           return
         }
 
-        // Get format from parent command (root program)
-        const format = (command.parent?.opts()?.format || 'toon') as OutputFormat
+        // Resolve --format from the global options. Use getOutputFormat
+        // (optsWithGlobals) rather than walking the parent chain by hand — the
+        // global option lives on the root command, and the hand-walked lookup
+        // here previously stopped one level short and silently ignored --format.
+        const format = getOutputFormat(command)
 
         // Format output based on selected format
         const output = formatOutput({ tasks: taskList }, { format, colors: process.stdout.isTTY })

--- a/test/commands/task-list-format.test.ts
+++ b/test/commands/task-list-format.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { Command } from 'commander'
+import * as realClient from '../../src/lib/asana-client'
+import * as realConfig from '../../src/lib/config'
+
+// Bun's `mock.restore()` does NOT revert `mock.module()` registrations, so the
+// module mocks below would leak into later test files and make the suite order-
+// dependent (e.g. a stubbed `loadConfig` breaks asana-client tests on CI where
+// the file order differs). Capture the real modules by value at load time and
+// re-install them once this file's tests finish.
+const REAL_CLIENT = { ...realClient }
+const REAL_CONFIG = { ...realConfig }
+
+/**
+ * Regression test for `task list` output format.
+ *
+ * The list action read the format from `command.parent` (the `task` command),
+ * but the global `--format` option lives on the ROOT command — two levels up.
+ * As a result `task list --format json` was silently ignored and always
+ * printed TOON. This wires up the real root→task→list hierarchy and asserts
+ * the global flag is honored. The asana client + config are mocked.
+ */
+describe('task list output format', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  afterAll(() => {
+    mock.module('../../src/lib/asana-client', () => REAL_CLIENT)
+    mock.module('../../src/lib/config', () => REAL_CONFIG)
+  })
+
+  async function runList(globalArgs: string[]): Promise<string> {
+    mock.module('../../src/lib/asana-client', () => ({
+      getAsanaClient: () => ({
+        tasks: {
+          findAll: async () => ({
+            data: [{ gid: '1', name: 'T', resource_type: 'task', resource_subtype: 'default_task' }],
+          }),
+        },
+      }),
+    }))
+    mock.module('../../src/lib/config', () => ({
+      loadConfig: () => ({ workspace: '123' }),
+    }))
+
+    const { createTaskCommand } = await import('../../src/commands/task')
+    const program = new Command()
+    program.name('asana').option('-f, --format <type>', 'Output format', 'toon')
+    program.addCommand(createTaskCommand())
+
+    const logs: string[] = []
+    const original = console.log
+    console.log = (...args: any[]) => {
+      logs.push(args.join(' '))
+    }
+    try {
+      await program.parseAsync([...globalArgs, 'task', 'list', '-a', 'me'], { from: 'user' })
+    }
+    finally {
+      console.log = original
+    }
+    return logs.join('\n')
+  }
+
+  test('honors global --format json', async () => {
+    const out = await runList(['--format', 'json'])
+    expect(out.trim().startsWith('{')).toBe(true)
+    expect(JSON.parse(out)).toHaveProperty('tasks')
+  })
+
+  test('defaults to TOON when no format is given', async () => {
+    const out = await runList([])
+    expect(out).toContain('tasks[')
+  })
+})


### PR DESCRIPTION
## Problem

`asana task list --format json` (and `-f json`) is silently ignored — `task list`
always prints TOON, while `task get`, `task create`, etc. honor the flag.

The list action read the format one level too shallow:

```ts
const format = (command.parent?.opts()?.format || 'toon')  // task command opts — no --format
```

The global `--format` option is defined on the **root** command, which is two
levels up from a `task list` action (root → task → list). Every other command
already walks `command.parent.parent`.

## Fix

Use `command.parent?.parent?.opts()?.format`, matching the sibling commands.

## Test

`test/commands/task-list-format.test.ts` builds the real root → task → list
hierarchy (asana client + config mocked) and asserts `--format json` produces
JSON while the default stays TOON. Fails against the old single-parent lookup.

## Notes

- One-line behavior fix; no other commands touched.
- Verified against the live API: `task list -f json` now emits JSON; default is
  still TOON. `bun run lint` and the new test pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `asana task list` to respect the global `--format`. `task list -f json` now outputs JSON; default stays TOON.

- **Bug Fixes**
  - Use `getOutputFormat(command)` (via `optsWithGlobals`) to read the global format instead of walking `parent`.
  - Add a regression test for root → task → list that checks `--format json` outputs JSON and the default prints TOON.

<sup>Written for commit 33022649d01b76889d718b8b8cd082d1014ff5b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `task list` command to reliably respect the global `--format` option. JSON output is now consistently produced when requested, and the default TOON formatting remains unchanged when `--format` is omitted.

* **Tests**
  * Added a regression test suite that verifies `task list --format json` returns parseable JSON containing `tasks`, and confirms the default TOON output when no `--format` flag is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->