### PR TITLE
docs(skill): add asana-cli Claude Code skill

### DIFF
--- a/.claude/skills/asana-cli/SKILL.md
+++ b/.claude/skills/asana-cli/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: asana-cli
 description: >-
-  Manage Asana from the terminal with the `asana` CLI — tasks, projects,
+  Manage Asana (아사나) from the terminal with the `asana` CLI — tasks, projects,
   sections, subtasks, comments, dependencies, followers, tags, attachments,
-  custom fields, batch import, and workspace/team/user lookups. Use this
-  whenever the user wants to create, list, find, update, complete, assign, or
-  delete Asana tasks or projects; add a comment, subtask, or due date; pull
-  their Asana to-do list; or otherwise touch Asana from the command line —
-  even when they only mention "Asana", paste an Asana task URL, or describe
-  work they want tracked there without naming the CLI.
+  custom fields, CSV/JSON batch import, and workspace/team/user lookups. Use
+  this whenever the user wants to create, list, find, count, update, complete,
+  assign, or delete Asana tasks or projects; add a comment, subtask, due date,
+  or follower; pull their Asana to-do list; or import tasks from a file into
+  Asana — even when they only say "Asana"/"아사나", paste an app.asana.com task
+  or project link, or describe work they want tracked there without naming the
+  CLI. (Does not apply to writing Asana API/SDK code or editing the asana CLI's
+  own source — only to operating Asana through the CLI.)
 ---
 
 # Asana CLI

--- a/.claude/skills/asana-cli/SKILL.md
+++ b/.claude/skills/asana-cli/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: asana-cli
+description: >-
+  Manage Asana from the terminal with the `asana` CLI — tasks, projects,
+  sections, subtasks, comments, dependencies, followers, tags, attachments,
+  custom fields, batch import, and workspace/team/user lookups. Use this
+  whenever the user wants to create, list, find, update, complete, assign, or
+  delete Asana tasks or projects; add a comment, subtask, or due date; pull
+  their Asana to-do list; or otherwise touch Asana from the command line —
+  even when they only mention "Asana", paste an Asana task URL, or describe
+  work they want tracked there without naming the CLI.
+---
+
+# Asana CLI
+
+`asana` is a command-line tool for Asana, powered by Bun. It speaks the same
+objects as Asana's web app — tasks, projects, sections, tags, users — addressed
+by their numeric `gid`. This skill is about driving it efficiently and safely.
+
+## Auth and workspace: act first, recover on error
+
+In a working setup the CLI is already logged in with a default workspace, so
+just run the command the user asked for — don't spend a turn on `auth whoami`
+"to be safe". Only fall back to diagnosis when a command actually fails:
+
+- **`✗ Not authenticated` / token error** → tell the user to run
+  `asana auth login --token <PAT>` (token from https://app.asana.com/0/my-apps).
+  Don't log in for them — it needs their secret. (OAuth via `asana auth login`
+  needs `ASANA_CLIENT_ID`/`ASANA_CLIENT_SECRET` env vars and a browser.)
+- **`Workspace is required …`** → run `asana workspace list`, then either pass
+  `-w <gid>` on the command or set it once with `asana workspace set-default <gid>`.
+
+Workspace resolution order: `-w` flag → config default → `ASANA_WORKSPACE` env
+var. `asana auth whoami` is the right tool to *confirm who you are or which
+workspace is default* — reach for it when that's genuinely in question, not as a
+reflex before every command.
+
+## Output format: keep it `toon`, switch to `json` to parse
+
+The default `toon` format is compact and easy to read — leave it as-is when you
+just need to see results. Add `--format json` (or `-f json`) **only when you
+need to extract a `gid` or field programmatically** (piping to `jq`, looping).
+Avoid `--format plain` unless the user explicitly wants the traditional view; it
+carries the least information per token.
+
+```bash
+asana task list -a me                      # read it yourself (toon)
+asana task list -a me -f json | jq -r '.tasks[].gid'   # extract gids
+```
+
+## The golden rule: resolve names to GIDs first
+
+The CLI does **not** look names up for you. A task, project, user, or tag is
+referenced by its numeric `gid`. When the user names something instead of giving
+a gid ("move the login bug to the Q3 board"), find the gid first, then act:
+
+| User says… | Resolve with |
+| --- | --- |
+| a person ("assign to Jin") | `asana user search "Jin"` → user gid (or just use `me`) |
+| a project ("the Q3 board") | `asana search projects "Q3"` or `asana project list -w <gid>` |
+| a task ("the login bug") | `asana search tasks "login"` (premium) or `asana task list -p <gid>` |
+| a tag, section, team | `asana tag list` / `asana section list <proj>` / `asana team list` |
+
+Chain it in one shot when you're confident, e.g.:
+
+```bash
+PROJ=$(asana search projects "Q3 roadmap" -f json | jq -r '.projects[0].gid')
+asana task create -n "Ship release notes" -p "$PROJ" --due-on 2026-07-01
+```
+
+If a lookup returns several plausible matches, show them to the user and ask
+which one rather than guessing — acting on the wrong gid is the main failure mode.
+
+## Common workflows
+
+```bash
+# My open tasks (current user, default workspace)
+asana task list -a me
+
+# Create a task in a project, assigned to me, with a due date
+# (the due-date flag is --due-on, same as `task update`; change it later with
+#  `asana task update <gid> --due-on <date>`)
+asana task create -n "Fix login redirect" -p 12345 -a me --due-on 2026-07-01
+
+# Look at a task someone linked (the trailing number in an Asana URL IS the gid)
+asana task get 1207891234567890
+
+# Add a comment, then complete it
+asana task comment add 1207891234567890 "Fixed in PR #482"
+asana task complete 1207891234567890
+
+# Break work down
+asana task subtask create 1207891234567890 -n "Write regression test"
+
+# Bulk import from a spreadsheet export
+asana task batch-create --file ./new-tasks.csv -w 12345
+```
+
+An Asana task/project URL like `https://app.asana.com/0/12345/1207891234567890`
+ends in the resource gid — pull it straight out instead of searching.
+
+## Safety: confirm before destroying
+
+`delete` (task/project/section/tag) and `batch-delete` are permanent — Asana has
+no undo. Before running any delete, confirm with the user what will be removed,
+and prefer `asana task complete` over `delete` when the user just means "I'm done
+with this." For `batch-delete`, review the GID file first and keep the
+confirmation prompt (don't reach for `--yes` unless the user explicitly asked to
+skip it).
+
+## Full command reference
+
+This covers the common path. For the complete list of commands, every flag,
+batch-file formats, custom fields, dependencies, search filters, and config/auth
+details, read `references/commands.md`. You can also trust `asana <command> --help`
+for any specific command's options.

--- a/.claude/skills/asana-cli/SKILL.md
+++ b/.claude/skills/asana-cli/SKILL.md
@@ -46,8 +46,8 @@ Avoid `--format plain` unless the user explicitly wants the traditional view; it
 carries the least information per token.
 
 ```bash
-asana task list -a me                      # read it yourself (toon)
-asana task list -a me -f json | jq -r '.tasks[].gid'   # extract gids
+asana task list -a me                                   # read it yourself (toon)
+asana task get 1207891234567890 -f json | jq -r '.task.gid'   # parse a field
 ```
 
 ## The golden rule: resolve names to GIDs first

--- a/.claude/skills/asana-cli/SKILL.md
+++ b/.claude/skills/asana-cli/SKILL.md
@@ -33,8 +33,8 @@ just run the command the user asked for — don't spend a turn on `auth whoami`
   `-w <gid>` on the command or set it once with `asana workspace set-default <gid>`.
 
 Workspace resolution order: `-w` flag → config default → `ASANA_WORKSPACE` env
-var. `asana auth whoami` is the right tool to *confirm who you are or which
-workspace is default* — reach for it when that's genuinely in question, not as a
+var. `asana auth whoami` is the right tool to _confirm who you are or which
+workspace is default_ — reach for it when that's genuinely in question, not as a
 reflex before every command.
 
 ## Output format: keep it `toon`, switch to `json` to parse
@@ -56,12 +56,12 @@ The CLI does **not** look names up for you. A task, project, user, or tag is
 referenced by its numeric `gid`. When the user names something instead of giving
 a gid ("move the login bug to the Q3 board"), find the gid first, then act:
 
-| User says… | Resolve with |
-| --- | --- |
-| a person ("assign to Jin") | `asana user search "Jin"` → user gid (or just use `me`) |
-| a project ("the Q3 board") | `asana search projects "Q3"` or `asana project list -w <gid>` |
-| a task ("the login bug") | `asana search tasks "login"` (premium) or `asana task list -p <gid>` |
-| a tag, section, team | `asana tag list` / `asana section list <proj>` / `asana team list` |
+| User says…                 | Resolve with                                                         |
+| -------------------------- | -------------------------------------------------------------------- |
+| a person ("assign to Jin") | `asana user search "Jin"` → user gid (or just use `me`)              |
+| a project ("the Q3 board") | `asana search projects "Q3"` or `asana project list -w <gid>`        |
+| a task ("the login bug")   | `asana search tasks "login"` (premium) or `asana task list -p <gid>` |
+| a tag, section, team       | `asana tag list` / `asana section list <proj>` / `asana team list`   |
 
 Chain it in one shot when you're confident, e.g.:
 

--- a/.claude/skills/asana-cli/references/commands.md
+++ b/.claude/skills/asana-cli/references/commands.md
@@ -1,0 +1,225 @@
+# Asana CLI — Full Command Reference
+
+Authoritative list of every `asana` command, its arguments, and options (v0.5.0).
+When in doubt about a flag, run `asana <command> --help` — per-command help is accurate.
+
+Conventions: `<required>`, `[optional]`. Most write commands print the created/updated
+object including its `gid` and `permalink_url`.
+
+## Table of contents
+
+- [Global options](#global-options)
+- [auth](#auth) — login / logout / whoami
+- [workspace](#workspace)
+- [task](#task) — create / list / get / update / move / complete / delete
+- [task subtask](#task-subtask)
+- [task dependency / dependent](#task-dependency--dependent)
+- [task comment](#task-comment)
+- [task follower](#task-follower)
+- [task tag](#task-tag)
+- [task attachments](#task-attachments)
+- [task custom-field](#task-custom-field)
+- [task batch operations](#task-batch-operations)
+- [project](#project)
+- [section](#section)
+- [tag](#tag)
+- [custom-field](#custom-field-definitions)
+- [search](#search)
+- [team](#team)
+- [user](#user)
+- [self-update](#self-update)
+- [config, auth, env details](#configuration--authentication-details)
+
+---
+
+## Global options
+
+`asana [-f|--format <type>] <command>`
+
+- `-f, --format <type>` — `toon` (default, token-efficient for LLMs), `json` (scripting), `plain` (human tables)
+
+---
+
+## auth
+
+- `asana auth login` — login via OAuth or PAT
+  - `--token <token>` — use Personal Access Token (recommended; from https://app.asana.com/0/my-apps)
+  - `-w, --workspace <workspace>` — set default workspace at login
+  - `--scope <scopes>` — OAuth scopes, space-separated
+  - `--no-browser` — copy-paste flow for headless/CI
+- `asana auth logout` — remove stored credentials
+- `asana auth whoami` — show current user, auth type, default workspace
+
+OAuth requires env vars `ASANA_CLIENT_ID` and `ASANA_CLIENT_SECRET`.
+
+## workspace
+
+- `asana workspace list` — list workspaces  `[--no-cache]`
+- `asana workspace get <gid>` — workspace details
+- `asana workspace users [gid]` — list users (defaults to configured workspace)
+- `asana workspace set-default <gid>` — persist default workspace to config
+
+## task
+
+- `asana task create` — create a task
+  - `-n, --name <name>` (required)
+  - `-d, --notes <notes>`
+  - `-a, --assignee <assignee>` — user GID
+  - `--due-on <date>` — YYYY-MM-DD (canonical; `--due` is a deprecated alias)
+  - `-w, --workspace <workspace>`
+  - `-p, --project <project>`
+- `asana task list` — list tasks (needs at least one of workspace/project/assignee)
+  - `-a, --assignee <assignee>` — `me` for current user
+  - `-w, --workspace <workspace>`
+  - `-p, --project <project>`
+  - `-c, --completed` — include completed (excluded by default)
+- `asana task get <gid>` — full details
+- `asana task update <gid>` — update fields
+  - `-n, --name <name>`
+  - `-d, --notes <notes>`
+  - `-a, --assignee <assignee>`
+  - `--due-on <date>` — YYYY-MM-DD
+  - `--start-on <date>` — YYYY-MM-DD
+  - `-c, --completed <boolean>` — `true`/`false`
+- `asana task move <gid>` — move to another project
+  - `-p, --project <project>` (required)
+  - `-s, --section <section>`
+- `asana task complete <gid>` — mark complete
+- `asana task delete <gid>` — permanently delete (destructive)
+
+## task subtask
+
+- `asana task subtask list <parent-gid>`  `[-r|--recursive]`
+- `asana task subtask create <parent-gid>`
+  - `-n, --name <name>` (required), `-d, --notes`, `-a, --assignee`, `--due-on <date>`
+- `asana task subtask add <task-gid> <parent-gid>` — convert existing task into a subtask
+
+## task dependency / dependent
+
+- `asana task dependency add <task-gid> <depends-on-gid>` — task is blocked by depends-on
+- `asana task dependency remove <task-gid> <depends-on-gid>`
+- `asana task dependency list <task-gid>` — tasks that block this one
+- `asana task dependent list <task-gid>` — tasks blocked by this one
+
+Asana caps combined dependencies + dependents at 50.
+
+## task comment
+
+- `asana task comment add <task-gid> <text>`  `[--html]` (rich text; auto-wraps in `<body>`)
+- `asana task comment list <task-gid>` — user comments only (excludes system events)
+
+## task follower
+
+- `asana task follower add <task-gid> <user-gid>` — user GID, email, or `me`
+- `asana task follower remove <task-gid> <user-gid>`
+- `asana task follower list <task-gid>`
+
+## task tag
+
+- `asana task tag add <task-gid> <tag-gid>`
+- `asana task tag remove <task-gid> <tag-gid>`
+- `asana task tag list <task-gid>`
+
+## task attachments
+
+- `asana task attach <task-gid> <file>` — upload a local file (streamed)
+- `asana task attachment list <task-gid>`
+- `asana task attachment download <attachment-gid>`  `[-o|--output <path>] [--force]`
+  - External attachments (e.g. Google Drive links) cannot be downloaded.
+
+## task custom-field
+
+- `asana task custom-field set <task-gid> <field-gid> <value>` — value coerced to field type (text/number/enum name or gid)
+- `asana task custom-field list <task-gid>`
+
+## task batch operations
+
+- `asana task batch-create --file <path>`  `[-w|--workspace <gid>]`
+  - JSON array of task objects (`name` required), or CSV with header row (`name`, optional `notes`/`assignee`/`due_on`/`completed`/`project`).
+- `asana task batch-update --file <path>`
+  - JSON array of `{gid, ...fields}` or `{"tasks":[...]}`. Each record needs `gid`.
+- `asana task batch-delete --file <path>`  `[--yes]` (destructive)
+  - Text file, one GID per line; `#` lines are comments. Prompts unless `--yes`.
+
+All batch commands print a summary: total / succeeded / failed (+ failure details).
+
+## project
+
+- `asana project create`
+  - `-n, --name <name>` (required), `-w, --workspace`, `-t, --team`, `-d, --notes`, `--color <color>`, `--public`
+- `asana project list` — needs workspace or team  `[-w] [-t] [-a|--archived]`
+- `asana project get <gid>`
+- `asana project update <gid>`
+  - `-n, --name`, `-d, --notes`, `--color <color>`, `--archived <boolean>`, `--public <boolean>`
+- `asana project delete <gid>` (destructive)
+
+## section
+
+- `asana section list <project-gid>`
+- `asana section create <project-gid>`
+  - `-n, --name <name>` (required), `--insert-before <section-gid>`, `--insert-after <section-gid>`
+- `asana section update <section-gid>`  `-n, --name <name>`
+- `asana section delete <section-gid>` (destructive)
+
+## tag
+
+- `asana tag list`  `[-w|--workspace]`
+- `asana tag create`
+  - `-n, --name <name>` (required), `-w, --workspace`, `-c, --color <color>` (e.g. `dark-red`), `-d, --notes`
+- `asana tag get <tag-gid>`
+- `asana tag update <tag-gid>`  `-n, --name`, `-c, --color`, `-d, --notes` (≥1 required)
+- `asana tag delete <tag-gid>` (destructive)
+
+## custom-field definitions
+
+- `asana custom-field list`  `[-w|--workspace]` — workspace's custom field definitions (gid/name/type)
+
+## search
+
+- `asana search tasks <query>` — full-text search (premium workspaces only)
+  - `-w, --workspace`, `-l, --limit <1-100>` (default 20), `-c, --completed <true|false>`, `-a, --assignee <gids,comma-separated>`
+- `asana search projects <query>` — typeahead project name search
+  - `-w, --workspace`, `-l, --limit <1-100>` (default 20)
+
+## team
+
+- `asana team list`  `[-w|--workspace] [--no-cache]`
+- `asana team get <gid>`
+- `asana team members <gid>`
+
+## user
+
+- `asana user me` — current user
+- `asana user get <user>` — GID, email, or `me`
+- `asana user search <query>` — fuzzy match by name/email  `[-w|--workspace]`
+- `asana user tasks <user>` — tasks assigned to user  `[-w|--workspace] [-c|--completed]`
+
+## self-update
+
+- `asana self-update`  `[--check]` — update CLI to latest (use `brew upgrade asana-cli` if installed via Homebrew)
+
+---
+
+## Configuration & authentication details
+
+**Config file:** `~/.asana-cli/config.json` — stores `accessToken`, `refreshToken` (OAuth),
+`authType` (`pat`/`oauth`), `workspace` (default), `expiresAt`, `scopes`.
+
+**Environment variables (override config):**
+- `ASANA_ACCESS_TOKEN` — PAT; used instead of config file if set
+- `ASANA_WORKSPACE` — default workspace GID
+- `ASANA_CLIENT_ID` / `ASANA_CLIENT_SECRET` — OAuth app credentials (for `auth login` OAuth flow)
+
+**Workspace resolution priority:** `-w` option → config default → `ASANA_WORKSPACE`.
+If none set, commands needing a workspace fail with:
+`"Workspace is required. Set default workspace or use -w option."`
+
+## Gotchas
+
+1. GIDs must be numeric strings. User-identifying args also accept `me` and (for followers/users) email.
+2. Dates are strict `YYYY-MM-DD`.
+3. `task move` removes the task from all current projects before adding the target.
+4. `search tasks` is a premium-only Asana feature; on free workspaces it errors.
+5. `workspace list` and `team list` cache results — use `--no-cache` for fresh data.
+6. Boolean update flags take an explicit value: `task update <gid> -c true`.
+7. Names are NOT resolved to GIDs automatically. Find the GID first (list/search/user search), then act.

--- a/.claude/skills/asana-cli/references/commands.md
+++ b/.claude/skills/asana-cli/references/commands.md
@@ -54,7 +54,7 @@ OAuth requires env vars `ASANA_CLIENT_ID` and `ASANA_CLIENT_SECRET`.
 
 ## workspace
 
-- `asana workspace list` — list workspaces  `[--no-cache]`
+- `asana workspace list` — list workspaces `[--no-cache]`
 - `asana workspace get <gid>` — workspace details
 - `asana workspace users [gid]` — list users (defaults to configured workspace)
 - `asana workspace set-default <gid>` — persist default workspace to config
@@ -89,7 +89,7 @@ OAuth requires env vars `ASANA_CLIENT_ID` and `ASANA_CLIENT_SECRET`.
 
 ## task subtask
 
-- `asana task subtask list <parent-gid>`  `[-r|--recursive]`
+- `asana task subtask list <parent-gid>` `[-r|--recursive]`
 - `asana task subtask create <parent-gid>`
   - `-n, --name <name>` (required), `-d, --notes`, `-a, --assignee`, `--due-on <date>`
 - `asana task subtask add <task-gid> <parent-gid>` — convert existing task into a subtask
@@ -105,7 +105,7 @@ Asana caps combined dependencies + dependents at 50.
 
 ## task comment
 
-- `asana task comment add <task-gid> <text>`  `[--html]` (rich text; auto-wraps in `<body>`)
+- `asana task comment add <task-gid> <text>` `[--html]` (rich text; auto-wraps in `<body>`)
 - `asana task comment list <task-gid>` — user comments only (excludes system events)
 
 ## task follower
@@ -124,7 +124,7 @@ Asana caps combined dependencies + dependents at 50.
 
 - `asana task attach <task-gid> <file>` — upload a local file (streamed)
 - `asana task attachment list <task-gid>`
-- `asana task attachment download <attachment-gid>`  `[-o|--output <path>] [--force]`
+- `asana task attachment download <attachment-gid>` `[-o|--output <path>] [--force]`
   - External attachments (e.g. Google Drive links) cannot be downloaded.
 
 ## task custom-field
@@ -134,11 +134,11 @@ Asana caps combined dependencies + dependents at 50.
 
 ## task batch operations
 
-- `asana task batch-create --file <path>`  `[-w|--workspace <gid>]`
+- `asana task batch-create --file <path>` `[-w|--workspace <gid>]`
   - JSON array of task objects (`name` required), or CSV with header row (`name`, optional `notes`/`assignee`/`due_on`/`completed`/`project`).
 - `asana task batch-update --file <path>`
   - JSON array of `{gid, ...fields}` or `{"tasks":[...]}`. Each record needs `gid`.
-- `asana task batch-delete --file <path>`  `[--yes]` (destructive)
+- `asana task batch-delete --file <path>` `[--yes]` (destructive)
   - Text file, one GID per line; `#` lines are comments. Prompts unless `--yes`.
 
 All batch commands print a summary: total / succeeded / failed (+ failure details).
@@ -147,7 +147,7 @@ All batch commands print a summary: total / succeeded / failed (+ failure detail
 
 - `asana project create`
   - `-n, --name <name>` (required), `-w, --workspace`, `-t, --team`, `-d, --notes`, `--color <color>`, `--public`
-- `asana project list` — needs workspace or team  `[-w] [-t] [-a|--archived]`
+- `asana project list` — needs workspace or team `[-w] [-t] [-a|--archived]`
 - `asana project get <gid>`
 - `asana project update <gid>`
   - `-n, --name`, `-d, --notes`, `--color <color>`, `--archived <boolean>`, `--public <boolean>`
@@ -158,21 +158,21 @@ All batch commands print a summary: total / succeeded / failed (+ failure detail
 - `asana section list <project-gid>`
 - `asana section create <project-gid>`
   - `-n, --name <name>` (required), `--insert-before <section-gid>`, `--insert-after <section-gid>`
-- `asana section update <section-gid>`  `-n, --name <name>`
+- `asana section update <section-gid>` `-n, --name <name>`
 - `asana section delete <section-gid>` (destructive)
 
 ## tag
 
-- `asana tag list`  `[-w|--workspace]`
+- `asana tag list` `[-w|--workspace]`
 - `asana tag create`
   - `-n, --name <name>` (required), `-w, --workspace`, `-c, --color <color>` (e.g. `dark-red`), `-d, --notes`
 - `asana tag get <tag-gid>`
-- `asana tag update <tag-gid>`  `-n, --name`, `-c, --color`, `-d, --notes` (≥1 required)
+- `asana tag update <tag-gid>` `-n, --name`, `-c, --color`, `-d, --notes` (≥1 required)
 - `asana tag delete <tag-gid>` (destructive)
 
 ## custom-field definitions
 
-- `asana custom-field list`  `[-w|--workspace]` — workspace's custom field definitions (gid/name/type)
+- `asana custom-field list` `[-w|--workspace]` — workspace's custom field definitions (gid/name/type)
 
 ## search
 
@@ -183,7 +183,7 @@ All batch commands print a summary: total / succeeded / failed (+ failure detail
 
 ## team
 
-- `asana team list`  `[-w|--workspace] [--no-cache]`
+- `asana team list` `[-w|--workspace] [--no-cache]`
 - `asana team get <gid>`
 - `asana team members <gid>`
 
@@ -191,12 +191,12 @@ All batch commands print a summary: total / succeeded / failed (+ failure detail
 
 - `asana user me` — current user
 - `asana user get <user>` — GID, email, or `me`
-- `asana user search <query>` — fuzzy match by name/email  `[-w|--workspace]`
-- `asana user tasks <user>` — tasks assigned to user  `[-w|--workspace] [-c|--completed]`
+- `asana user search <query>` — fuzzy match by name/email `[-w|--workspace]`
+- `asana user tasks <user>` — tasks assigned to user `[-w|--workspace] [-c|--completed]`
 
 ## self-update
 
-- `asana self-update`  `[--check]` — update CLI to latest (use `brew upgrade asana-cli` if installed via Homebrew)
+- `asana self-update` `[--check]` — update CLI to latest (use `brew upgrade asana-cli` if installed via Homebrew)
 
 ---
 
@@ -206,6 +206,7 @@ All batch commands print a summary: total / succeeded / failed (+ failure detail
 `authType` (`pat`/`oauth`), `workspace` (default), `expiresAt`, `scopes`.
 
 **Environment variables (override config):**
+
 - `ASANA_ACCESS_TOKEN` — PAT; used instead of config file if set
 - `ASANA_WORKSPACE` — default workspace GID
 - `ASANA_CLIENT_ID` / `ASANA_CLIENT_SECRET` — OAuth app credentials (for `auth login` OAuth flow)

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ asana
 
 # please plugin runtime state
 .please/state/
+
+# Asana CLI skill — eval scratch & evals may contain private workspace data
+.claude/skills/*-workspace/
+.claude/skills/asana-cli/evals/


### PR DESCRIPTION
## What

Adds a Claude Code skill that teaches Claude to drive the `asana` CLI.

- `.claude/skills/asana-cli/SKILL.md` — workflow guidance: auth/workspace
  recovery (only on failure, not as a reflex), output-format guidance
  (TOON for reading, JSON for parsing), the "resolve names to GIDs first"
  rule, extracting a gid from an app.asana.com URL, common recipes, and a
  safety note on destructive deletes.
- `.claude/skills/asana-cli/references/commands.md` — full command reference
  (every command, args, options, auth/config details, gotchas).
- `.gitignore` — excludes the skill's eval scratch/evals, which reference a
  private workspace.

## How it was validated

Built with the skill-creator workflow over two eval iterations against a live
Asana workspace, plus a description-triggering optimization pass:

- **Efficiency:** on discovery-heavy advanced commands the skill cuts steps
  vs. an unaided baseline (e.g. comment-then-complete: 3 vs 7 commands);
  token usage came out slightly lower with the skill after removing an
  always-on `auth whoami` preamble.
- **Triggering precision:** 20-query trigger eval shows no false positives on
  near-misses — the yoga "아사나" homonym, Asana API/SDK coding, edits to the
  CLI's own source, and Jira/Trello/Calendar/Notion all correctly do not fire.

## Related

Surfaced and fixed three CLI bugs while testing the skill end to end:
- #31 PAT login (merged)
- #34 `task create --due` due date (merged)
- #35 `task list` ignoring `--format` (open)

The skill assumes those fixes; #31 and #34 are already on `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Code skill for operating the `asana` CLI with clear workflows, guardrails, and a full command reference to speed up task/project management. Sets precise trigger boundaries, including Korean "아사나" and pasted Asana links.

- New Features
  - `.claude/skills/asana-cli/SKILL.md` + `references/commands.md`: workflows and safety (recover auth/workspace only on failure, `toon` vs `json`, resolve names to GIDs, extract GIDs from `app.asana.com` links, common recipes, delete safety); clear trigger scope (Asana/“아사나” mentions, pasted links, count/follower/CSV‑import) with explicit exclusions for API/SDK coding and editing the `asana` CLI; full `asana` v0.5.0 command reference with flags, batch formats, config/auth, and gotchas; JSON extraction example now uses `task get -f json | jq` to match current CLI behavior.
  - `.gitignore`: ignores `.claude/skills/*-workspace/` and `.claude/skills/asana-cli/evals/` to keep private workspace data out of the repo; applied Prettier formatting (no content changes).

<sup>Written for commit 0ae818a6ab5b756471910898a7d6bc624d2abc04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Asana CLI skill guide covering terminal authentication/workspace handling, output format tips (toon vs json), name→GID workflow, end-to-end usage examples, and safety guidance for destructive commands.
  * Added a full Asana CLI command reference (v0.5.0) with global/per-command syntax, flags, configuration/auth details, and a “Gotchas” section.
* **Chores**
  * Updated ignore rules to exclude additional Asana CLI skill evaluation artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->