### PR TITLE
chore: add markdown link checking (hk pre-commit hook + CI job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,18 @@ jobs:
 
       - name: Run ESLint
         run: bun run lint
+
+  link-check:
+    name: Markdown Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mise (node + markdown-link-check)
+        uses: jdx/mise-action@v2
+
+      # Reuse the same hk.pkl globs/excludes as the local pre-commit hook so the
+      # check is identical everywhere. hk isn't in mise.toml [tools] (no Intel-Mac
+      # binary), so install it on the fly here (CI runs linux).
+      - name: Check markdown links
+        run: mise exec hk@1.48.0 -- hk check --all

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -2,7 +2,11 @@
   "ignorePatterns": [
     { "pattern": "^https?://localhost" },
     { "pattern": "^https?://127\\.0\\.0\\.1" },
-    { "pattern": "^https?://0\\.0\\.0\\.0" }
+    { "pattern": "^https?://0\\.0\\.0\\.0" },
+    { "comment": "Nuxt Content 내부 라우트(렌더링 시 해석되며 파일로 검사 불가)", "pattern": "^/" },
+    { "comment": "Asana 앱 페이지는 인증이 필요해 봇 요청을 403으로 차단", "pattern": "^https?://app\\.asana\\.com/" },
+    { "comment": "npm 패키지 페이지는 봇 요청을 403으로 차단", "pattern": "^https?://(www\\.)?npmjs\\.com/" },
+    { "comment": "npm.im 단축 URL은 봇 요청을 403으로 차단", "pattern": "^https?://npm\\.im/" }
   ],
   "httpHeaders": [
     {

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,21 @@
+{
+  "ignorePatterns": [
+    { "pattern": "^https?://localhost" },
+    { "pattern": "^https?://127\\.0\\.0\\.1" },
+    { "pattern": "^https?://0\\.0\\.0\\.0" }
+  ],
+  "httpHeaders": [
+    {
+      "comment": "일부 사이트는 기본 UA를 봇으로 차단하므로 브라우저 UA를 전송한다",
+      "urls": ["https://", "http://"],
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (compatible; markdown-link-check)"
+      }
+    }
+  ],
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
+}

--- a/dev-docs/GIT_HOOKS.md
+++ b/dev-docs/GIT_HOOKS.md
@@ -41,8 +41,8 @@ hk install
 ## Useful commands
 
 ```bash
-mise run lint:links        # check links in ALL markdown files
-hk check --all             # same as above (the underlying command)
+mise run lint:links        # check links in ALL markdown files directly
+hk check --all             # check links via hk hook runner
 hk run pre-commit          # run the pre-commit hook on staged files manually
 git commit --no-verify ...  # bypass the hook in an emergency
 ```

--- a/dev-docs/GIT_HOOKS.md
+++ b/dev-docs/GIT_HOOKS.md
@@ -1,0 +1,48 @@
+# Git Hooks
+
+This repo uses [`hk`](https://hk.jdx.dev) to manage git hooks. The only hook
+configured today validates markdown links with
+[`markdown-link-check`](https://github.com/tcort/markdown-link-check) before each
+commit.
+
+## What runs
+
+- **pre-commit** — runs `markdown-link-check` on staged `*.md` files only and
+  blocks the commit if any link is dead. `CHANGELOG.md` (auto-generated) and
+  `node_modules/**` are excluded.
+
+Config lives in:
+
+- `hk.pkl` — hook/step definitions
+- `.markdown-link-check.json` — link-check behavior (timeouts, 429 retries,
+  ignored hosts, User-Agent)
+
+## One-time setup
+
+`markdown-link-check` is provisioned by mise; `hk` must be installed separately
+because it ships no `darwin/amd64` (Intel Mac) binary.
+
+```bash
+# 1. tools (node, bun, markdown-link-check)
+mise trust && mise install
+
+# 2. install hk itself
+mise use -g hk      # linux / Apple Silicon
+# or, on Intel Mac:
+brew install hk
+
+# 3. wire the git hooks into .git/hooks
+hk install
+```
+
+> The pre-commit hook lives in `.git/hooks/` and is **not** committed, so every
+> fresh clone must run `hk install` once.
+
+## Useful commands
+
+```bash
+mise run lint:links        # check links in ALL markdown files
+hk check --all             # same as above (the underlying command)
+hk run pre-commit          # run the pre-commit hook on staged files manually
+git commit --no-verify ...  # bypass the hook in an emergency
+```

--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -38,7 +38,7 @@ Get Started
 color: neutral
 icon: simple-icons-github
 size: xl
-to: https://github.com/amondnet/asana
+to: https://github.com/pleaseai/asana
 variant: outline
 
 ---

--- a/docs/content/ko/1.guide/1.getting-started.md
+++ b/docs/content/ko/1.guide/1.getting-started.md
@@ -14,7 +14,7 @@ Get up and running with Asana CLI in minutes.
 Clone the repository and install dependencies using Bun:
 
 ```bash
-git clone https://github.com/amondnet/asana.git
+git clone https://github.com/pleaseai/asana.git
 cd asana
 bun install
 ```

--- a/docs/content/ko/index.md
+++ b/docs/content/ko/index.md
@@ -38,7 +38,7 @@ trailing-icon: i-lucide-arrow-right
 color: neutral
 icon: simple-icons-github
 size: xl
-to: https://github.com/amondnet/asana
+to: https://github.com/pleaseai/asana
 variant: outline
 
 ---

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,20 @@
+amends "package://github.com/jdx/hk/releases/download/v1.48.0/hk@1.48.0#/Config.pkl"
+
+// markdown-link-check validates every link in changed markdown files.
+// Binary comes from mise ("npm:markdown-link-check"); config from .markdown-link-check.json.
+local linters = new Mapping<String, Step> {
+    ["markdown-link-check"] {
+        glob = List("*.md", "**/*.md")
+        exclude = List("node_modules/**", "CHANGELOG.md")
+        check = "markdown-link-check --config .markdown-link-check.json --quiet {{ files }}"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ run = "bun run lint"
 
 [tasks."lint:links"]
 description = "Check markdown links (all files)"
-run = "hk check --all"
+run = "find . -name '*.md' -not -path '*/node_modules/*' -not -name 'CHANGELOG.md' -exec markdown-link-check --config .markdown-link-check.json --quiet {} +"
 
 [tasks.test]
 description = "Test"

--- a/mise.toml
+++ b/mise.toml
@@ -1,29 +1,36 @@
-# mise.toml — PassionFactory 표준 도구 체인
-# 사용법: `mise trust && mise install`
-# 상세: Skill("standards:dev-tooling")
+# mise.toml — PassionFactory standard toolchain
+# Usage: `mise trust && mise install`
+# Details: Skill("standards:dev-tooling")
 
 [tools]
 node = "22"
 bun = "latest"
+"npm:markdown-link-check" = "3"        # markdown link validation (pre-commit)
+# hk (git hook manager) is not listed in [tools] because it ships no darwin/amd64 binary.
+# Install: `mise use -g hk` (linux / arm64) or `brew install hk` (Intel Mac). See dev-docs/GIT_HOOKS.md.
 
 [tasks.dev]
-description = "개발 서버 실행"
+description = "Run the dev server"
 run = "bun run dev"
 
 [tasks.build]
-description = "빌드"
+description = "Build"
 run = "bun run build"
 
 [tasks.lint]
-description = "린트"
+description = "Lint"
 run = "bun run lint"
 
+[tasks."lint:links"]
+description = "Check markdown links (all files)"
+run = "hk check --all"
+
 [tasks.test]
-description = "테스트"
+description = "Test"
 run = "bun run test"
 
 [tasks.check]
-description = "lint → test 일괄 검사"
+description = "Run lint then test"
 depends = [
   "lint",
   "test"

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@
 [tools]
 node = "22"
 bun = "latest"
-"npm:markdown-link-check" = "3"        # markdown link validation (pre-commit)
+"npm:markdown-link-check" = "3" # markdown link validation (pre-commit)
 # hk (git hook manager) is not listed in [tools] because it ships no darwin/amd64 binary.
 # Install: `mise use -g hk` (linux / arm64) or `brew install hk` (Intel Mac). See dev-docs/GIT_HOOKS.md.
 

--- a/test/commands/auth-login-pat.test.ts
+++ b/test/commands/auth-login-pat.test.ts
@@ -1,4 +1,14 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import * as realAsana from 'asana'
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import * as realConfig from '../../src/lib/config'
+
+// Bun's `mock.restore()` does NOT revert `mock.module()` registrations, so the
+// module mocks below leak into later test files and make the suite order-
+// dependent (e.g. a stubbed `loadConfig` breaks asana-client tests on CI where
+// the file order differs). Capture the real modules by value at load time and
+// re-install them once this file's tests finish.
+const REAL_ASANA = { ...realAsana }
+const REAL_CONFIG = { ...realConfig }
 
 /**
  * Regression test for the PAT login path.
@@ -12,6 +22,11 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 describe('auth login --token (PAT)', () => {
   afterEach(() => {
     mock.restore()
+  })
+
+  afterAll(() => {
+    mock.module('asana', () => REAL_ASANA)
+    mock.module('../../src/lib/config', () => REAL_CONFIG)
   })
 
   test('validates the token via the v3 SDK and saves a PAT config', async () => {

--- a/test/commands/task-create-due.test.ts
+++ b/test/commands/task-create-due.test.ts
@@ -1,4 +1,13 @@
-import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { afterAll, afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import * as realClient from '../../src/lib/asana-client'
+import * as realConfig from '../../src/lib/config'
+
+// Bun's `mock.restore()` does NOT revert `mock.module()` registrations, so the
+// module mocks below leak into later test files and make the suite order-
+// dependent. Capture the real modules by value at load time and re-install them
+// once this file's tests finish.
+const REAL_CLIENT = { ...realClient }
+const REAL_CONFIG = { ...realConfig }
 
 /**
  * Regression test for `task create` due date handling.
@@ -12,6 +21,11 @@ import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
 describe('task create due date', () => {
   afterEach(() => {
     mock.restore()
+  })
+
+  afterAll(() => {
+    mock.module('../../src/lib/asana-client', () => REAL_CLIENT)
+    mock.module('../../src/lib/config', () => REAL_CONFIG)
   })
 
   async function runCreate(args: string[]): Promise<any> {


### PR DESCRIPTION
## Summary

Add markdown link validation using [`markdown-link-check`](https://github.com/tcort/markdown-link-check), wired in at two layers with a single shared config (`hk.pkl`):

- **pre-commit hook** (via [`hk`](https://hk.jdx.dev)) — checks staged `*.md` files before each commit
- **CI job** — checks all `*.md` files on push/PR to `main`

## Changes

- `hk.pkl` — `pre-commit` + `check` hooks running `markdown-link-check`
- `.markdown-link-check.json` — timeouts, 429 retries, ignored hosts (localhost), browser UA
- `mise.toml` — provision `markdown-link-check`; add `lint:links` task (file written in English)
- `.github/workflows/ci.yml` — `Markdown Link Check` job reusing the same `hk.pkl` globs/excludes
- `dev-docs/GIT_HOOKS.md` — setup & usage docs

`CHANGELOG.md` (auto-generated) and `node_modules/**` are excluded from checks.

## Notes

- **`hk install` required per clone** — the pre-commit hook lives in `.git/hooks/` and is not committed.
- **`hk` is not in `mise.toml [tools]`** — it ships no `darwin/amd64` (Intel Mac) binary. Install via `mise use -g hk` (linux / Apple Silicon) or `brew install hk` (Intel Mac). CI installs it on the fly (`mise exec hk@1.48.0`).
- The CI link-check is **strict (blocking)**; external link outages/rate-limits can cause flaky failures. Mitigation options (continue-on-error or a weekly cron) can be added if desired.

## Verification

- Broken link → commit **blocked** (✗ ERROR); valid link → passes (verified by dogfooding this PR's own commits).
- `hk check --all --plan` → 47 files matched (`CHANGELOG.md` excluded as expected).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Markdown link checking with `markdown-link-check` in `hk` pre-commit and CI to catch broken links early. Also fixes broken docs links and stabilizes tests that were flaky due to leaked module mocks.

- **New Features**
  - `hk` pre-commit checks staged `*.md`; excludes `CHANGELOG.md` and `node_modules/**`.
  - CI job runs the same check on push/PRs to `main` using `hk.pkl` globs.
  - Shared `.markdown-link-check.json` sets timeouts, 429 retries, browser UA; ignores localhost, Nuxt internal routes, and bot-blocked hosts (`app.asana.com`, `npmjs.com`, `npm.im`).
  - `mise.toml` provisions `npm:markdown-link-check` and adds `lint:links` that runs the checker directly (no `hk` needed); docs in `dev-docs/GIT_HOOKS.md`.

- **Bug Fixes**
  - Replaced dead GitHub links with `https://github.com/pleaseai/asana`.
  - Restored real modules in tests in `afterAll` to avoid `mock.module()` leaks and order-dependent CI failures.

<sup>Written for commit b366bffbaea6711899bf2414b4327464181f5fca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Markdown link validation to CI lint checks and the pre-commit hook for staged Markdown files.
* **Bug Fixes**
  * Improved test isolation so Bun module mocks no longer leak between test files.
* **Documentation**
  * Documented git hook setup and configuration for link checking.
  * Updated repository links across English and Korean documentation.
* **Chores**
  * Updated lint/link-check tasks and tooling configuration to support the new link validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->