### PR TITLE
fix(docs): use canonical www.conventionalcommits.org URL

### DIFF
--- a/dev-docs/commit-convention.md
+++ b/dev-docs/commit-convention.md
@@ -2,7 +2,7 @@
 
 Lint your conventional commits
 
-Shareable `commitlint` config enforcing [conventional commits](https://conventionalcommits.org/).
+Shareable `commitlint` config enforcing [conventional commits](https://www.conventionalcommits.org/).
 Use with [@commitlint/cli](https://npm.im/@commitlint/cli) and [@commitlint/prompt-cli](https://npm.im/@commitlint/prompt-cli).
 
 ## Getting started


### PR DESCRIPTION
## Problem

The `markdown-link-check` CI job (added in #38) fails repo-wide:

```
ERROR: 1 dead link found in dev-docs/commit-convention.md !
[✖] https://conventionalcommits.org/ → Status: 0
```

The link is not actually dead — the site returns HTTP 200 — but the non-www
host redirects to `www`, and that connection-level redirect yields `Status: 0`
on CI runners. Because the job scans every `*.md` in the repo, this blocks CI
on **all** PRs that touch markdown (e.g. #37).

## Fix

Point directly at the canonical `https://www.conventionalcommits.org/` (HTTP
200, no redirect hop). Verified locally — the pre-commit `markdown-link-check`
hook passes on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to use the canonical https://www.conventionalcommits.org/ instead of https://conventionalcommits.org/ to avoid a redirect. This fixes `markdown-link-check` false failures in CI and unblocks PRs that touch markdown.

<sup>Written for commit ce85e6018fba964644e59a8185364659f625a193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit convention documentation for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->