### PR TITLE
feat: structured agent-readable error output (AXI §6, Phase 1)

### DIFF
--- a/dev-docs/AXI-ADOPTION.md
+++ b/dev-docs/AXI-ADOPTION.md
@@ -1,0 +1,177 @@
+# AXI Adoption Plan
+
+This document tracks the adoption of the
+[AXI standard](https://agentskills.io) (Agent eXperience Interface) — ergonomic
+conventions for CLI tools consumed by autonomous agents — in the Asana CLI.
+
+The error-output model and exit-code policy are formalized in
+[ADR-003](./adr/003-axi-agent-experience.md). This document is the broader,
+living roadmap.
+
+## Why
+
+The Asana CLI is invoked by agents (Claude Code, Codex, OpenCode) over shell and
+its stdout is parsed as data. ADR-002 already made data output token-efficient
+(TOON by default). The remaining work makes the *rest* of the surface — errors,
+empty states, counts, schemas, the home view, and session integration —
+agent-shaped as well. The roadmap is measured against two complementary standards:
+**AXI** (output/presentation) and the **Agent DX CLI Scale** (input/safety/
+introspection); see the scorecard below.
+
+## Gap matrix (AXI §1–§10 vs current)
+
+| § | AXI requirement | Current state | Verdict | Effort |
+|---|---|---|---|---|
+| 1 | Token-efficient TOON output | `encodeToon` is the default (`formatter.ts`) | ✅ Met | — |
+| 2 | Minimal schemas + `--fields` | Full objects emitted; no `--fields` | ⚠️ Partial | M |
+| 3 | Content truncation + `--full` | No truncation of long fields | ❌ Missing | M |
+| 4 | Pre-computed aggregates (total count) | Lists omit total count | ❌ Missing | S–M |
+| 5 | Definitive empty states | `chalk.yellow('No tasks found')` | ❌ Violates | S |
+| 6 | **Structured errors → stdout, exit codes, idempotency, no prompts** | stderr + Chalk, `exit(1)`, idempotency unclear | ❌ **Core violation** | M–L |
+| 7 | Ambient session integration (SessionStart dashboard) | None | ❌ Missing | M |
+| 8 | Content-first home view | No-arg → commander help (stderr) | ❌ Violates | M |
+| 9 | Contextual disclosure (next-step hints) | None | ❌ Missing | M |
+| 10 | bin path, description, `--help` | Only `--version`; no home identity | ⚠️ Partial | S |
+
+## Agent DX scorecard
+
+AXI covers output and presentation. The complementary
+[Agent DX CLI Scale](../.claude/skills/agent-dx-cli-scale/SKILL.md) (0–21, from
+"You Need to Rewrite Your CLI for AI Agents") scores the **input, safety, and
+introspection** surfaces AXI does not. We track it here so the roadmap is measured
+against both.
+
+| Axis | Now | Target | Basis |
+|------|-----|--------|-------|
+| 1. Machine-readable output | 1 | 3 | Success output consistent (TOON/JSON, all cmds); errors still stderr+Chalk → fixed by Phase 1 |
+| 2. Raw payload input | 1 | 3 | Only `batch-update --file` passes through arbitrary API fields; single mutations are flag-only, no stdin → Phase 6 |
+| 3. Schema introspection | 0 | 2 | Only commander `--help` text; no machine schema → Phase 7 |
+| 4. Context window discipline | 0 | 2 | No `--fields` mask / pagination control (TOON is orthogonal) → Phase 3 |
+| 5. Input hardening | 2 | 3 | Strict numeric GID (`^\d+$`) blocks traversal/encoding in IDs; gaps: no CWD path sandbox on `--file`, coverage unaudited |
+| 6. Safety rails | 0 | 2 | No `--dry-run`, no response sanitization → Phase 8 |
+| 7. Agent knowledge packaging | 1 | 3 | CLAUDE.md exists; no CLI-usage skill library/guardrails → Phase 5 |
+| **Total** | **5 / 21** | **~18 / 21** | Now: *Human-only* (top edge). After roadmap: *Agent-first* |
+
+**Multi-surface (bonus, unscored):** MCP ❌ (not in this binary) · extension/plugin ❌
+(Homebrew distribution is not agent-native) · headless auth ✅ (`ASANA_ACCESS_TOKEN`,
+PAT). MCP is tracked as D9 below.
+
+> The roadmap's AXI phases (1–5) alone lift the total to ~11–12 (*Agent-ready*).
+> Reaching *Agent-first* requires the input/safety axes in Phases 6–8 + the MCP
+> surface (D9).
+
+## Decisions
+
+| ID | Topic | Status |
+|----|-------|--------|
+| D1 | Dual-mode error output (toon/json → stdout structured; plain → stderr human) | ✅ Decided — ADR-003 |
+| D2 | Backward compatibility: freeze `plain`, ship as semver **minor** | ✅ Decided — ADR-003 |
+| D5 | Exit codes: 0 success/no-op, 1 error, 2 usage | ✅ Decided — ADR-003 |
+| D3 | Home view: tiered "light live" (workspaces + hints; offline/auth fallback) (§8) | ✅ Decided — ADR-004 |
+| D4 | Keep `formatter.ts` as canonical boundary; adopt toolkit `parseFields`/`filterFields` underneath | ✅ Decided — ADR-004 |
+| D6 | Raw JSON payload input (`--json`/stdin) on single mutations, mapping to API schema (Agent DX axis 2) | ⏳ Open — future ADR |
+| D7 | Machine-readable schema introspection (`--help --json` or `describe`) (axis 3) | ⏳ Open — future ADR |
+| D8 | `--dry-run` on all mutating commands (axis 6) | ⏳ Open — future ADR |
+| D9 | MCP (stdio JSON-RPC) surface from the same binary (multi-surface) | ⏳ Open — separate ADR (large) |
+
+## Phased plan
+
+All phases follow the repo's TDD discipline (Red → Green → Refactor), separate
+structural from behavioral commits, and use conventional commits. Documentation
+and code are in English (repos/ convention).
+
+### Phase 0 — Foundation (structural)
+
+- Author ADR-003 (done) for D1 / D2 / D5.
+- New shared helper `src/lib/axi-output.ts`: `emitError({ code, message, help, context })`,
+  `emitEmpty(collection)`, `withCount(list, total)`, `helpHints([...])`. Reuses
+  `encodeToon` from `@pleaseai/cli-toolkit`. Tests first.
+
+### Phase 1 — §6 Structured errors (highest ROI)
+
+- Make `error-handler.ts` and the `ValidationError` path format-aware (D1).
+- Narrow `ValidationError.errorId` from `string` to `ErrorId`.
+- Introduce exit code `2` for usage errors (D5); validate required flags before any
+  API call.
+- Idempotent mutations: `task complete` / `delete` on an already-final task →
+  acknowledge, exit 0.
+- Regression + output-snapshot tests per change.
+
+### Phase 2 — §5 empty states + §4 counts
+
+- `No tasks found` → structured `tasks: 0 ... found`.
+- Add `count: N of M total` to list output. Start with high-traffic commands
+  (task, project, search), then roll out across the remaining lists.
+
+### Phase 3 — §2 / §3 minimal schemas + `--fields` + truncation
+
+- Global `--fields` option using toolkit `parseFields` / `filterFields` (already
+  available, currently unused), wired underneath `formatter.ts` per D4 (ADR-004).
+- Reduce default list schemas to ~3–4 fields; full detail in detail views.
+- Truncate long fields (e.g. description) with a `--full` escape hatch and a total
+  size hint.
+
+### Phase 4 — §8 / §9 / §10 home view + disclosure + help
+
+- Content-first no-arg home view: bin path + one-line description + live content +
+  help hints. Tiered "light live" per D3 (ADR-004): unauthenticated → `auth login`
+  hint (no network); authenticated → one cheap workspaces call + hints; offline →
+  degrade to static identity + hint.
+- Contextual next-step hints on list and mutation responses.
+- Per-subcommand `--help` reference (flags, defaults, 2–3 examples).
+
+### Phase 5 — §7 ambient session integration (optional, last)
+
+- `asana hook install`-style command to register SessionStart context for Claude
+  Code / Codex / OpenCode with a token-minimal dashboard.
+- Secondary: ship an installable SKILL.md generated from the home-view content.
+
+## Agent DX phases (input / safety / introspection)
+
+These extend the roadmap beyond AXI to reach *Agent-first*. They are independent of
+Phases 1–5 and can be sequenced by ROI — **Phase 8 (`--dry-run`) is high-value and
+low-risk and may be pulled forward right after Phase 1.**
+
+### Phase 6 — Raw payload input (axis 2, D6)
+
+- Accept a raw JSON payload on single mutating commands via `--json '<obj>'` or
+  stdin, mapping directly to the Asana API schema (the `batch-update --file`
+  passthrough in `toTaskData` is the existing precedent).
+- Convenience flags remain; raw payload is additive (no translation loss).
+
+### Phase 7 — Schema introspection (axis 3, D7)
+
+- Expose a machine-readable schema: `asana <cmd> --help --json` or an
+  `asana describe` command emitting params, types, required fields, enums as JSON.
+- Lets agents discover the surface at runtime instead of relying on pre-stuffed docs.
+
+### Phase 8 — Safety rails: dry-run (axis 6, D8)
+
+- `--dry-run` on every mutating command: validate and echo the resolved request
+  without side effects, exit 0. High ROI, low risk.
+- Consider response sanitization against prompt injection in API data (axis 6 → 3)
+  as a later, separate step.
+
+### Out of roadmap — MCP surface (D9)
+
+- An MCP (stdio JSON-RPC) server exposing the same operations as typed tools is the
+  largest multi-surface win but a significant architectural decision → its own ADR,
+  not folded into these phases.
+
+## Risks & safety net
+
+- **Broad touch surface** (17 of 18 commands) → regression risk. Mitigated by the
+  existing 31 unit + 6 e2e tests plus new output snapshots.
+- **stdout error transition is potentially breaking** → mitigated by freezing the
+  `plain` path (D2); release-please manages the semver-minor bump.
+- **Home-view network calls** (Phase 4) → require unauthenticated/offline fallback
+  (D3) and a token budget.
+
+## References
+
+- [AXI — Agent eXperience Interface](https://agentskills.io)
+- [Agent DX CLI Scale](../.claude/skills/agent-dx-cli-scale/SKILL.md)
+- [TOON specification](https://toonformat.dev/reference/spec.html)
+- [ADR-002: TOON Output Format](./adr/002-toon-output-format.md)
+- [ADR-003: AXI Agent eXperience Conventions](./adr/003-axi-agent-experience.md)
+- [ADR-004: AXI Home View and Output-Formatter Boundary](./adr/004-axi-home-view-and-formatter.md)

--- a/dev-docs/AXI-ADOPTION.md
+++ b/dev-docs/AXI-ADOPTION.md
@@ -36,7 +36,7 @@ introspection); see the scorecard below.
 ## Agent DX scorecard
 
 AXI covers output and presentation. The complementary
-[Agent DX CLI Scale](../.claude/skills/agent-dx-cli-scale/SKILL.md) (0–21, from
+**Agent DX CLI Scale** (0–21, from
 "You Need to Rewrite Your CLI for AI Agents") scores the **input, safety, and
 introspection** surfaces AXI does not. We track it here so the roadmap is measured
 against both.
@@ -170,7 +170,7 @@ low-risk and may be pulled forward right after Phase 1.**
 ## References
 
 - [AXI — Agent eXperience Interface](https://agentskills.io)
-- [Agent DX CLI Scale](../.claude/skills/agent-dx-cli-scale/SKILL.md)
+- Agent DX CLI Scale — local skill `agent-dx-cli-scale` (from "You Need to Rewrite Your CLI for AI Agents")
 - [TOON specification](https://toonformat.dev/reference/spec.html)
 - [ADR-002: TOON Output Format](./adr/002-toon-output-format.md)
 - [ADR-003: AXI Agent eXperience Conventions](./adr/003-axi-agent-experience.md)

--- a/dev-docs/adr/003-axi-agent-experience.md
+++ b/dev-docs/adr/003-axi-agent-experience.md
@@ -1,0 +1,150 @@
+# ADR-003: AXI (Agent eXperience Interface) Conventions
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-23
+
+## Context
+
+The Asana CLI is increasingly consumed by autonomous agents (Claude Code, Codex,
+OpenCode) that invoke it through shell execution and parse its stdout. ADR-002
+already moved data output to a token-efficient **TOON** default, which satisfies
+the first AXI principle. However, an audit against the full
+[AXI standard](https://agentskills.io) (Agent eXperience Interface) revealed that
+the rest of the CLI's surface is still shaped for humans, not agents.
+
+The most significant gap is **error handling**: `src/lib/error-handler.ts` and the
+`ValidationError` path (`src/lib/validators.ts`) write Chalk-colored, human-oriented
+text to **stderr** and call `process.exit(1)`. Agents do not read stderr, so they
+cannot observe *why* a command failed — they only see a non-zero exit code. This
+directly violates AXI §6 ("structured errors on stdout in the same structured
+format as normal output").
+
+Secondary gaps (definitive empty states §5, total-count aggregates §4, minimal
+schemas + `--fields` §2, content truncation §3, content-first home view §8,
+contextual disclosure §9, ambient session integration §7) are tracked in the
+roadmap (`dev-docs/AXI-ADOPTION.md`) and out of scope for this ADR. This ADR fixes
+the **error output model and exit-code policy** only, because that is the
+highest-value, agent-blocking gap and it establishes the output-boundary pattern
+the other phases reuse.
+
+The project already owns the building blocks: stable error codes in
+`src/constants/errorIds.ts` (`ERROR_IDS` / `ErrorId`), `ValidationError` carrying
+`errorId` + `context`, and `encodeToon` from `@pleaseai/cli-toolkit/output`. No new
+runtime dependency (e.g. a structured-diagnostics library) is required to satisfy
+AXI — the gap is a wiring problem at the output boundary, not a missing library.
+
+## Decision Drivers
+
+- **Agent-readability**: failures must be machine-parseable on stdout, not stderr.
+- **Backward compatibility**: existing human/script users of `plain` output must
+  not break.
+- **Reuse over dependency**: leverage existing `ERROR_IDS` + `encodeToon` rather
+  than introduce a new error/diagnostics dependency.
+- **Consistency**: error output should mirror the success output's format selection
+  (`--format toon|json|plain`).
+
+## Considered Options
+
+### Option 1: Keep stderr + Chalk for all errors
+
+**Pros:** zero work; familiar to human users.
+**Cons:** agents cannot read failures (AXI §6 violation). Rejected.
+
+### Option 2: Always emit structured errors to stdout (all formats)
+
+**Pros:** simplest mental model; fully AXI-compliant.
+**Cons:** breaking change for `plain` users and scripts that read stderr; would
+force a semver **major**. Rejected for now (see D2).
+
+### Option 3: Format-aware dual-mode error output (Selected)
+
+When `--format` is `toon` or `json`, emit a **structured error to stdout**
+(`error`, `code`, `help`, optional `context`) using the same encoder as success
+output. When `--format` is `plain`, retain the existing **stderr + Chalk**
+human-oriented behavior.
+
+**Pros:** AXI-compliant for agents; fully backward-compatible for humans/scripts;
+semver **minor**; reuses existing infrastructure.
+**Cons:** two code paths to maintain and test.
+
+## Decision
+
+Adopt **Option 3 (format-aware dual-mode error output)** with the following rules.
+
+### D1 — Dual-mode error output
+
+- `--format toon|json` → structured error written to **stdout** via the shared
+  output encoder. Shape:
+
+  ```
+  error: <translated, actionable message>
+  code: <ERROR_IDS value>
+  help: <specific next-step command, not "see --help">
+  context: <optional key/values>
+  ```
+
+- `--format plain` (and the default when output is an interactive TTY) → existing
+  **stderr + Chalk** human-readable behavior is preserved unchanged.
+- Errors are **translated** at the boundary: extract actionable meaning, never leak
+  raw Asana SDK payloads or stack traces (DEBUG mode may still dump full detail to
+  stderr).
+
+### D2 — Backward compatibility: minor release
+
+The `plain` path is frozen for backward compatibility. Only `toon`/`json` gain the
+new stdout behavior. This is a **non-breaking, semver-minor** change managed via
+release-please.
+
+### D5 — Exit-code policy
+
+- `0` — success, **including idempotent no-ops** (e.g. completing an already-complete
+  task acknowledges and exits 0).
+- `1` — error (the agent's intent genuinely cannot be satisfied).
+- `2` — usage error (missing/invalid required flags), validated **before** any API
+  call. No interactive prompts — a missing required value fails immediately with a
+  structured usage error.
+
+### Implementation note
+
+A shared helper module (e.g. `src/lib/axi-output.ts`) will own `emitError(...)` so
+both `handleAsanaError` and the `ValidationError` path route through one
+format-aware boundary. `ValidationError.errorId` will be narrowed from `string` to
+`ErrorId` as part of this work.
+
+## Consequences
+
+### Positive
+
+- Agents can read and act on failures (AXI §6 satisfied for `toon`/`json`).
+- No new runtime dependency; binary size unaffected.
+- Establishes the output-boundary pattern reused by roadmap phases 2–4.
+- `ErrorId` type tightening removes an existing loose-typing weakness.
+
+### Negative
+
+- Two error-rendering code paths to maintain and snapshot-test.
+- Broad touch surface: 17 of 18 command files invoke the error/output path.
+
+### Neutral
+
+- Open items deferred to follow-up ADRs: **D3** (home-view content scope and
+  unauthenticated/offline fallback, AXI §8) and **D4** (deduplicating local
+  `src/utils/formatter.ts` against `@pleaseai/cli-toolkit` `outputData`).
+
+## References
+
+- [AXI — Agent eXperience Interface](https://agentskills.io)
+- [TOON specification](https://toonformat.dev/reference/spec.html)
+- ADR-002: TOON Output Format for CLI (`./002-toon-output-format.md`)
+- Roadmap: AXI Adoption Plan (`../AXI-ADOPTION.md`)
+- Code: `src/lib/error-handler.ts`, `src/lib/validators.ts`,
+  `src/constants/errorIds.ts`, `src/utils/formatter.ts`
+
+## Related Issues
+
+- #TBD: AXI §6 — structured errors on stdout + exit-code policy

--- a/dev-docs/adr/003-axi-agent-experience.md
+++ b/dev-docs/adr/003-axi-agent-experience.md
@@ -88,8 +88,9 @@ Adopt **Option 3 (format-aware dual-mode error output)** with the following rule
   context: <optional key/values>
   ```
 
-- `--format plain` (and the default when output is an interactive TTY) → existing
-  **stderr + Chalk** human-readable behavior is preserved unchanged.
+- `--format plain` → existing **stderr + Chalk** human-readable behavior is
+  preserved unchanged. (`--format` defaults to `toon` regardless of TTY; `plain`
+  is opt-in.)
 - Errors are **translated** at the boundary: extract actionable meaning, never leak
   raw Asana SDK payloads or stack traces (DEBUG mode may still dump full detail to
   stderr).

--- a/dev-docs/adr/004-axi-home-view-and-formatter.md
+++ b/dev-docs/adr/004-axi-home-view-and-formatter.md
@@ -1,0 +1,125 @@
+# ADR-004: AXI Home View and Output-Formatter Boundary
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-23
+
+## Context
+
+[ADR-003](./003-axi-agent-experience.md) settled the AXI error-output model and
+exit-code policy but explicitly deferred two items:
+
+- **D3** — the content scope of the content-first home view (AXI §8), including the
+  unauthenticated and offline fallback behavior.
+- **D4** — whether to deduplicate the local `src/utils/formatter.ts` against
+  `@pleaseai/cli-toolkit`'s `outputData`.
+
+This ADR resolves both.
+
+### Relevant facts
+
+- Auth state is cheaply derivable with **no network call**: `getAccessToken()`
+  (`src/lib/config.ts`) reads `~/.asana-cli/config.json` or `ASANA_ACCESS_TOKEN`.
+- `AsanaConfig` carries an optional `workspace?` field, so a default workspace
+  *may* be configured but is not guaranteed.
+- The cli-toolkit `OutputFormat` is `'json' | 'toon'` **only** — it has no `plain`
+  format. The local `formatter.ts` is the sole provider of `plain` (human-readable,
+  colored) output, which is load-bearing for ADR-003's human-facing error path.
+- `formatter.ts` already delegates `toon` to the toolkit's `encodeToon`; the only
+  real overlap with the toolkit is trivial `json` stringification.
+- The toolkit already ships `parseFields` / `filterFields` (unused in this repo),
+  which the AXI §2 `--fields` work (roadmap Phase 3) needs.
+
+## Decision
+
+### D3 — Home view: tiered, "light live"
+
+Running `asana` with no arguments renders a content-first home view (AXI §8/§10):
+
+1. **Always** — `bin` (absolute path, `~`-collapsed) and a one-line `description`
+   (AXI §10).
+2. **Unauthenticated** (no token) — no network call. Show a structured hint to run
+   `asana auth login`. Definitive and fast.
+3. **Authenticated** — one cheap live call: **list workspaces**, plus next-step help
+   hints. Workspaces are small and stable, keeping the per-session token budget
+   minimal (AXI §7/§8).
+4. **Offline / call failure** — degrade to the static identity (bin + description)
+   plus a hint; never hang or dump a raw network error.
+
+Example (authenticated):
+
+```
+bin: ~/.local/bin/asana
+description: Manage Asana tasks from the CLI
+
+workspaces[2]{gid,name}:
+  12345,Acme
+  67890,Personal
+
+help[2]:
+  Run `asana task list -w <gid>` to see tasks
+  Run `asana project list -w <gid>` for projects
+```
+
+Rejected alternatives: a **rich** view (default-workspace incomplete tasks) — more
+useful but requires a configured `workspace`, a heavier call, and more fallback
+paths; and a **static** view (command groups only) — fastest but fails AXI §8's
+"live content" intent. "Light live" is the balance of usefulness, cost, and
+robustness.
+
+### D4 — Keep `formatter.ts` as the canonical output boundary
+
+Do **not** replace `formatOutput` with the toolkit's `outputData`. Rationale:
+`outputData` cannot render `plain` and writes directly to stdout, bypassing the
+format-aware error boundary ADR-003 depends on.
+
+Instead:
+
+- `src/utils/formatter.ts` remains the single, format-aware output boundary and the
+  owner of `plain`.
+- Underneath it, adopt toolkit **primitives** to eliminate drift and avoid
+  reimplementation: `encodeToon` (already used) for `toon`, and `parseFields` /
+  `filterFields` for the `--fields` work (Phase 3).
+- The shared `axi-output.ts` helper (ADR-003) routes errors and empty states
+  through this same boundary.
+
+## Consequences
+
+### Positive
+
+- Home view gives agents actionable live state on the first call (AXI §8) while
+  staying cheap and offline-safe.
+- No new runtime dependency; the binary stays lean.
+- Output stays consistent across success, empty, and error paths because everything
+  flows through one boundary.
+- `--fields` (Phase 3) reuses battle-tested toolkit primitives instead of bespoke
+  filtering.
+
+### Negative
+
+- The home view adds a network-dependent path that needs explicit offline/auth-state
+  tests.
+- `plain` remains a locally maintained format (the toolkit will not cover it).
+
+### Neutral
+
+- If a configured default workspace becomes common, a richer home view can be
+  revisited in a later ADR without changing this boundary.
+
+## References
+
+- [AXI — Agent eXperience Interface](https://agentskills.io)
+- ADR-003: AXI Agent eXperience Conventions (`./003-axi-agent-experience.md`)
+- ADR-002: TOON Output Format for CLI (`./002-toon-output-format.md`)
+- Roadmap: AXI Adoption Plan (`../AXI-ADOPTION.md`)
+- Code: `src/lib/config.ts`, `src/utils/formatter.ts`,
+  `@pleaseai/cli-toolkit/output` (`outputData`, `parseFields`, `filterFields`)
+
+## Related Issues
+
+- #TBD: AXI §8 — content-first home view
+- #TBD: AXI §2 — `--fields` + minimal schemas via toolkit primitives

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -12,6 +12,8 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 |----|-------|--------|------|
 | [001](./001-distribution-strategy.md) | CLI Distribution Strategy | Accepted | 2025-10-25 |
 | [002](./002-toon-output-format.md) | TOON Output Format for CLI | Proposed | 2025-10-30 |
+| [003](./003-axi-agent-experience.md) | AXI (Agent eXperience Interface) Conventions | Accepted | 2026-06-23 |
+| [004](./004-axi-home-view-and-formatter.md) | AXI Home View and Output-Formatter Boundary | Accepted | 2026-06-23 |
 
 ## ADR Template
 

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -21,6 +21,9 @@ import { createTaskTagCommand } from './task-tag'
  * Exit on a validation failure, emitting a structured error to stdout for
  * machine formats (AXI §6). For `plain` the validator has already written a
  * human-readable message to stderr, so we avoid printing it twice.
+ *
+ * emitError writes the payload synchronously, so the following process.exit
+ * cannot truncate it when stdout is piped.
  */
 function failValidation(error: ValidationError, command: Command): never {
   const format = getOutputFormat(command)

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -3,7 +3,7 @@ import type { OutputFormat } from '../utils/formatter'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import { getAsanaClient } from '../lib/asana-client'
-import { emitResult } from '../lib/axi-output'
+import { emitError, emitResult } from '../lib/axi-output'
 import { loadConfig } from '../lib/config'
 import { handleAsanaError, isNotFoundError } from '../lib/error-handler'
 import { validateDateFormat, validateGid, validateUpdateFields, ValidationError } from '../lib/validators'
@@ -16,6 +16,19 @@ import { createDependencyCommand, createDependentCommand } from './task-dependen
 import { createFollowerCommand } from './task-follower'
 import { createSubtaskCommand } from './task-subtask'
 import { createTaskTagCommand } from './task-tag'
+
+/**
+ * Exit on a validation failure, emitting a structured error to stdout for
+ * machine formats (AXI §6). For `plain` the validator has already written a
+ * human-readable message to stderr, so we avoid printing it twice.
+ */
+function failValidation(error: ValidationError, command: Command): never {
+  const format = getOutputFormat(command)
+  if (format !== 'plain') {
+    emitError({ code: error.errorId, message: error.message, context: error.context }, format)
+  }
+  process.exit(1)
+}
 
 export function createTaskCommand(): Command {
   const task = new Command('task')
@@ -82,7 +95,7 @@ export function createTaskCommand(): Command {
       }
       catch (error) {
         if (error instanceof ValidationError) {
-          process.exit(1)
+          failValidation(error, command)
         }
         handleAsanaError(error, 'Task creation', {
           'Task name': options.name,
@@ -255,7 +268,7 @@ export function createTaskCommand(): Command {
       }
       catch (error) {
         if (error instanceof ValidationError) {
-          process.exit(1)
+          failValidation(error, command)
         }
         handleAsanaError(error, 'Task update', { 'Task GID': gid }, getOutputFormat(command))
       }
@@ -322,7 +335,7 @@ export function createTaskCommand(): Command {
       }
       catch (error) {
         if (error instanceof ValidationError) {
-          process.exit(1)
+          failValidation(error, command)
         }
         handleAsanaError(error, 'Task move', {
           'Task GID': gid,
@@ -352,7 +365,7 @@ export function createTaskCommand(): Command {
       }
       catch (error) {
         if (error instanceof ValidationError) {
-          process.exit(1)
+          failValidation(error, command)
         }
         handleAsanaError(error, 'Task completion', { 'Task GID': gid }, getOutputFormat(command))
       }
@@ -376,7 +389,7 @@ export function createTaskCommand(): Command {
       }
       catch (error) {
         if (error instanceof ValidationError) {
-          process.exit(1)
+          failValidation(error, command)
         }
         // Idempotent delete: an already-gone task is a no-op success (AXI §6).
         if (isNotFoundError(error)) {

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { getAsanaClient } from '../lib/asana-client'
 import { loadConfig } from '../lib/config'
-import { handleAsanaError } from '../lib/error-handler'
+import { handleAsanaError, isNotFoundError } from '../lib/error-handler'
 import { validateDateFormat, validateGid, validateUpdateFields, ValidationError } from '../lib/validators'
 import { formatOutput, getOutputFormat } from '../utils/formatter'
 import { createTaskCustomFieldCommand } from './custom-field'
@@ -335,10 +335,12 @@ export function createTaskCommand(): Command {
     .command('complete')
     .description('Mark a task as complete')
     .argument('<gid>', 'Task GID')
-    .action(async (gid: string) => {
+    .action(async (gid: string, _options: any, command: Command) => {
       try {
         validateGid(gid, 'Task GID')
         const client = getAsanaClient()
+        // Completing an already-complete task is not an error in the Asana API,
+        // so this mutation is already idempotent (exit 0).
         await client.tasks.update(gid, { completed: true })
 
         console.log(chalk.green(`✓ Task ${gid} marked as complete`))
@@ -347,7 +349,7 @@ export function createTaskCommand(): Command {
         if (error instanceof ValidationError) {
           process.exit(1)
         }
-        handleAsanaError(error, 'Task completion', { 'Task GID': gid })
+        handleAsanaError(error, 'Task completion', { 'Task GID': gid }, getOutputFormat(command))
       }
     })
 
@@ -355,7 +357,7 @@ export function createTaskCommand(): Command {
     .command('delete')
     .description('Delete a task')
     .argument('<gid>', 'Task GID')
-    .action(async (gid: string) => {
+    .action(async (gid: string, _options: any, command: Command) => {
       try {
         validateGid(gid, 'Task GID')
         const client = getAsanaClient()
@@ -367,7 +369,12 @@ export function createTaskCommand(): Command {
         if (error instanceof ValidationError) {
           process.exit(1)
         }
-        handleAsanaError(error, 'Task deletion', { 'Task GID': gid })
+        // Idempotent delete: an already-gone task is a no-op success (AXI §6).
+        if (isNotFoundError(error)) {
+          console.log(chalk.green(`✓ Task ${gid} already deleted (no-op)`))
+          return
+        }
+        handleAsanaError(error, 'Task deletion', { 'Task GID': gid }, getOutputFormat(command))
       }
     })
 

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -87,7 +87,7 @@ export function createTaskCommand(): Command {
           'Task name': options.name,
           'Workspace': workspace,
           'Project': options.project,
-        })
+        }, getOutputFormat(command))
       }
     })
 
@@ -153,7 +153,7 @@ export function createTaskCommand(): Command {
           Workspace: workspace,
           Project: options.project,
           Assignee: options.assignee,
-        })
+        }, getOutputFormat(command))
       }
     })
 
@@ -185,7 +185,7 @@ export function createTaskCommand(): Command {
         console.log(output)
       }
       catch (error) {
-        handleAsanaError(error, 'Task retrieval', { 'Task GID': gid })
+        handleAsanaError(error, 'Task retrieval', { 'Task GID': gid }, getOutputFormat(command))
       }
     })
 
@@ -256,7 +256,7 @@ export function createTaskCommand(): Command {
         if (error instanceof ValidationError) {
           process.exit(1)
         }
-        handleAsanaError(error, 'Task update', { 'Task GID': gid })
+        handleAsanaError(error, 'Task update', { 'Task GID': gid }, getOutputFormat(command))
       }
     })
 
@@ -327,7 +327,7 @@ export function createTaskCommand(): Command {
           'Task GID': gid,
           'Target project': options.project,
           'Target section': options.section,
-        })
+        }, getOutputFormat(command))
       }
     })
 

--- a/src/commands/task.ts
+++ b/src/commands/task.ts
@@ -3,6 +3,7 @@ import type { OutputFormat } from '../utils/formatter'
 import chalk from 'chalk'
 import { Command } from 'commander'
 import { getAsanaClient } from '../lib/asana-client'
+import { emitResult } from '../lib/axi-output'
 import { loadConfig } from '../lib/config'
 import { handleAsanaError, isNotFoundError } from '../lib/error-handler'
 import { validateDateFormat, validateGid, validateUpdateFields, ValidationError } from '../lib/validators'
@@ -341,9 +342,13 @@ export function createTaskCommand(): Command {
         const client = getAsanaClient()
         // Completing an already-complete task is not an error in the Asana API,
         // so this mutation is already idempotent (exit 0).
-        await client.tasks.update(gid, { completed: true })
+        const result = await client.tasks.update(gid, { completed: true })
 
-        console.log(chalk.green(`✓ Task ${gid} marked as complete`))
+        emitResult(
+          { task: { status: 'success', gid: result.gid ?? gid, completed: result.completed ?? true } },
+          `✓ Task ${gid} marked as complete`,
+          getOutputFormat(command),
+        )
       }
       catch (error) {
         if (error instanceof ValidationError) {
@@ -363,7 +368,11 @@ export function createTaskCommand(): Command {
         const client = getAsanaClient()
         await client.tasks.delete(gid)
 
-        console.log(chalk.green(`✓ Task ${gid} deleted`))
+        emitResult(
+          { task: { status: 'success', gid, deleted: true } },
+          `✓ Task ${gid} deleted`,
+          getOutputFormat(command),
+        )
       }
       catch (error) {
         if (error instanceof ValidationError) {
@@ -371,7 +380,11 @@ export function createTaskCommand(): Command {
         }
         // Idempotent delete: an already-gone task is a no-op success (AXI §6).
         if (isNotFoundError(error)) {
-          console.log(chalk.green(`✓ Task ${gid} already deleted (no-op)`))
+          emitResult(
+            { task: { status: 'already_deleted', gid } },
+            `✓ Task ${gid} already deleted (no-op)`,
+            getOutputFormat(command),
+          )
           return
         }
         handleAsanaError(error, 'Task deletion', { 'Task GID': gid }, getOutputFormat(command))

--- a/src/lib/axi-output.ts
+++ b/src/lib/axi-output.ts
@@ -10,13 +10,14 @@
 
 import type { ErrorId } from '../constants/errorIds'
 import type { OutputFormat } from '../utils/formatter'
+import { inspect } from 'node:util'
 import { encodeToon } from '@pleaseai/cli-toolkit/output'
 import chalk from 'chalk'
 import { formatOutput } from '../utils/formatter'
 
 export interface AxiError {
   /** Stable, machine-readable error code. */
-  code: ErrorId | string
+  code: ErrorId
 
   /** Translated, actionable message readable by both humans and agents. */
   message: string
@@ -100,7 +101,8 @@ function emitErrorPlain(error: AxiError): void {
   if (error.context) {
     for (const [key, value] of Object.entries(error.context)) {
       if (value !== undefined && value !== null) {
-        console.error(chalk.gray(`  ${key}: ${value}`))
+        const rendered = typeof value === 'string' ? value : inspect(value, { depth: null, colors: false })
+        console.error(chalk.gray(`  ${key}: ${rendered}`))
       }
     }
   }

--- a/src/lib/axi-output.ts
+++ b/src/lib/axi-output.ts
@@ -10,6 +10,7 @@
 
 import type { ErrorId } from '../constants/errorIds'
 import type { OutputFormat } from '../utils/formatter'
+import * as nodeFs from 'node:fs'
 import { inspect } from 'node:util'
 import { encodeToon } from '@pleaseai/cli-toolkit/output'
 import chalk from 'chalk'
@@ -73,7 +74,9 @@ export function emitError(error: AxiError, format: OutputFormat): void {
     return
   }
 
-  console.log(formatStructuredError(error, format))
+  // Write synchronously to stdout (fd 1): callers exit immediately afterwards,
+  // and an async console.log could be truncated by process.exit when piped.
+  nodeFs.writeSync(1, `${formatStructuredError(error, format)}\n`)
 }
 
 /**

--- a/src/lib/axi-output.ts
+++ b/src/lib/axi-output.ts
@@ -1,0 +1,91 @@
+/**
+ * AXI structured output helpers.
+ *
+ * Renders errors in the format the caller selected. Machine formats (toon/json)
+ * emit a structured payload to stdout so agents can read failures; the human
+ * `plain` format keeps the existing colored stderr behavior.
+ *
+ * See ADR-003 (AXI Agent eXperience Conventions) for the error-output model.
+ */
+
+import type { ErrorId } from '../constants/errorIds'
+import type { OutputFormat } from '../utils/formatter'
+import { encodeToon } from '@pleaseai/cli-toolkit/output'
+import chalk from 'chalk'
+
+export interface AxiError {
+  /** Stable, machine-readable error code. */
+  code: ErrorId | string
+
+  /** Translated, actionable message readable by both humans and agents. */
+  message: string
+
+  /** Specific next-step command that resolves the error. */
+  help?: string
+
+  /** Optional disambiguating key/values. */
+  context?: Record<string, unknown>
+}
+
+/**
+ * Build the structured error payload with a stable key order
+ * (`error`, `code`, `help`, `context`). Pure — no side effects.
+ *
+ * `help` and `context` are included only when present (context must be
+ * non-empty), so minimal errors stay minimal.
+ */
+export function buildErrorPayload(error: AxiError): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    error: error.message,
+    code: error.code,
+  }
+
+  if (error.help) {
+    payload.help = error.help
+  }
+
+  if (error.context && Object.keys(error.context).length > 0) {
+    payload.context = error.context
+  }
+
+  return payload
+}
+
+/**
+ * Render a structured error for a machine format. Pure — returns a string.
+ */
+export function formatStructuredError(error: AxiError, format: 'toon' | 'json'): string {
+  const payload = buildErrorPayload(error)
+  return format === 'toon' ? encodeToon(payload) : JSON.stringify(payload, null, 2)
+}
+
+/**
+ * Emit an error in the selected format.
+ *
+ * - `toon` / `json`: structured payload to **stdout** (agent-readable, AXI §6).
+ * - `plain`: human-readable, colored, to **stderr** (backward-compatible).
+ */
+export function emitError(error: AxiError, format: OutputFormat): void {
+  if (format === 'plain') {
+    emitErrorPlain(error)
+    return
+  }
+
+  console.log(formatStructuredError(error, format))
+}
+
+function emitErrorPlain(error: AxiError): void {
+  console.error(chalk.red(`✗ ${error.message}`))
+
+  if (error.context) {
+    for (const [key, value] of Object.entries(error.context)) {
+      if (value !== undefined && value !== null) {
+        console.error(chalk.gray(`  ${key}: ${value}`))
+      }
+    }
+  }
+
+  if (error.help) {
+    console.error(chalk.gray(`  Help: ${error.help}`))
+  }
+}

--- a/src/lib/axi-output.ts
+++ b/src/lib/axi-output.ts
@@ -12,6 +12,7 @@ import type { ErrorId } from '../constants/errorIds'
 import type { OutputFormat } from '../utils/formatter'
 import { encodeToon } from '@pleaseai/cli-toolkit/output'
 import chalk from 'chalk'
+import { formatOutput } from '../utils/formatter'
 
 export interface AxiError {
   /** Stable, machine-readable error code. */
@@ -72,6 +73,25 @@ export function emitError(error: AxiError, format: OutputFormat): void {
   }
 
   console.log(formatStructuredError(error, format))
+}
+
+/**
+ * Emit a successful result in the selected format.
+ *
+ * - `toon` / `json`: structured `data` to stdout (agent-readable).
+ * - `plain`: the human-friendly `plainMessage` (colored) to stdout.
+ *
+ * Keeps machine output parseable while preserving the existing human UX, so an
+ * agent parsing stdout never receives stray prose (Pragmatic Programmer —
+ * orthogonality).
+ */
+export function emitResult(data: unknown, plainMessage: string, format: OutputFormat): void {
+  if (format === 'plain') {
+    console.log(chalk.green(plainMessage))
+    return
+  }
+
+  console.log(formatOutput(data, { format }))
 }
 
 function emitErrorPlain(error: AxiError): void {

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -137,7 +137,9 @@ export function handleAsanaError(
   context: Record<string, any>,
   format: OutputFormat = 'plain',
 ): never {
-  // Machine formats: structured error to stdout (AXI §6)
+  // Machine formats: structured error to stdout (AXI §6). emitError writes the
+  // payload synchronously, so the following process.exit cannot truncate it
+  // when stdout is piped.
   if (format !== 'plain') {
     emitError(translateAsanaError(error, operation, context), format)
     process.exit(1)

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -2,19 +2,137 @@
  * Centralized error handling utilities
  *
  * Provides consistent error handling across all commands.
+ *
+ * Machine formats (toon/json) emit a structured error to stdout so agents can
+ * read failures; the human `plain` format keeps the existing colored stderr
+ * output unchanged for backward compatibility. See ADR-003 (AXI §6).
  */
 
 import type { ErrorId } from '../constants/errorIds'
+import type { OutputFormat } from '../utils/formatter'
+import type { AxiError } from './axi-output'
 import chalk from 'chalk'
+import { ERROR_IDS } from '../constants/errorIds'
+import { emitError } from './axi-output'
 
 /**
- * Handle Asana API errors with specific messages and guidance
+ * Translate a raw Asana SDK / HTTP / network error into a structured AxiError
+ * (stable code + actionable help). Pure — no side effects.
+ */
+export function translateAsanaError(
+  error: any,
+  operation: string,
+  context: Record<string, any>,
+): AxiError {
+  // Asana SDK structured errors
+  if (error?.value?.errors) {
+    const asanaError = error.value.errors[0]
+    return {
+      code: ERROR_IDS.API_ERROR,
+      message: `${operation} failed: ${asanaError?.message ?? 'Unknown error'}`,
+      help: asanaError?.help,
+      context,
+    }
+  }
+
+  // HTTP status code errors
+  if (error?.status) {
+    return translateHttpError(error.status, operation, context)
+  }
+
+  // Network errors
+  if (error?.code === 'ENOTFOUND' || error?.code === 'ECONNREFUSED' || error?.code === 'ETIMEDOUT') {
+    return {
+      code: ERROR_IDS.NETWORK_ERROR,
+      message: 'Network error',
+      help: 'Could not connect to Asana API. Check your internet connection.',
+      context,
+    }
+  }
+
+  // Unknown error
+  return {
+    code: ERROR_IDS.API_ERROR,
+    message: `${operation} failed`,
+    context: error?.message ? { ...context, error: error.message } : context,
+  }
+}
+
+/**
+ * Translate an HTTP status code into a structured AxiError. Pure.
+ */
+function translateHttpError(
+  status: number,
+  operation: string,
+  context: Record<string, any>,
+): AxiError {
+  switch (status) {
+    case 404:
+      return {
+        code: ERROR_IDS.API_ERROR,
+        message: 'Resource not found',
+        help: 'The resource may have been deleted or you may not have access to it.',
+        context,
+      }
+
+    case 401:
+      return {
+        code: ERROR_IDS.AUTH_FAILED,
+        message: 'Authentication failed',
+        help: 'Your access token may have expired. Run "asana auth login" to re-authenticate.',
+      }
+
+    case 403:
+      return {
+        code: ERROR_IDS.PERMISSION_DENIED,
+        message: 'Permission denied',
+        help: 'You do not have permission to perform this operation.',
+        context,
+      }
+
+    case 429:
+      return {
+        code: ERROR_IDS.RATE_LIMIT_EXCEEDED,
+        message: 'Rate limit exceeded',
+        help: 'Please wait a moment and try again. Reduce request frequency or use batch operations.',
+      }
+
+    case 500:
+    case 502:
+    case 503:
+      return {
+        code: ERROR_IDS.API_ERROR,
+        message: 'Asana server error',
+        help: 'The Asana service is experiencing issues. Please try again later.',
+      }
+
+    default:
+      return {
+        code: ERROR_IDS.API_ERROR,
+        message: `${operation} failed (HTTP ${status})`,
+        context,
+      }
+  }
+}
+
+/**
+ * Handle Asana API errors with specific messages and guidance.
+ *
+ * For `toon`/`json` the error is emitted as a structured payload to stdout; for
+ * `plain` (the default) the original human-readable stderr behavior is used.
  */
 export function handleAsanaError(
   error: any,
   operation: string,
   context: Record<string, any>,
+  format: OutputFormat = 'plain',
 ): never {
+  // Machine formats: structured error to stdout (AXI §6)
+  if (format !== 'plain') {
+    emitError(translateAsanaError(error, operation, context), format)
+    process.exit(1)
+  }
+
   // Asana SDK structured errors
   if (error.value?.errors) {
     const asanaError = error.value.errors[0]

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -16,6 +16,16 @@ import { ERROR_IDS } from '../constants/errorIds'
 import { emitError } from './axi-output'
 
 /**
+ * Whether an error represents a missing resource (HTTP 404). Pure.
+ *
+ * Used to make destructive mutations idempotent: deleting an already-gone
+ * resource is a no-op success rather than an error (AXI §6).
+ */
+export function isNotFoundError(error: any): boolean {
+  return error?.status === 404
+}
+
+/**
  * Translate a raw Asana SDK / HTTP / network error into a structured AxiError
  * (stable code + actionable help). Pure — no side effects.
  */

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -5,13 +5,14 @@
  * Validates before API calls to provide clear error messages.
  */
 
+import type { ErrorId } from '../constants/errorIds'
 import { existsSync, statSync } from 'node:fs'
 import chalk from 'chalk'
 import { ERROR_IDS } from '../constants/errorIds'
 
 export class ValidationError extends Error {
   constructor(
-    public errorId: string,
+    public errorId: ErrorId,
     message: string,
     public context: Record<string, any> = {},
   ) {

--- a/test/lib/axi-output.test.ts
+++ b/test/lib/axi-output.test.ts
@@ -1,0 +1,112 @@
+/**
+ * AXI structured output helper tests.
+ *
+ * Covers the format-aware error rendering introduced for AXI §6 (ADR-003):
+ * machine formats (toon/json) emit a structured payload to stdout, while the
+ * human `plain` format keeps colored stderr output.
+ */
+
+import { describe, expect, mock, spyOn, test } from 'bun:test'
+import { ERROR_IDS } from '../../src/constants/errorIds'
+import {
+  buildErrorPayload,
+  emitError,
+  formatStructuredError,
+} from '../../src/lib/axi-output'
+
+describe('buildErrorPayload', () => {
+  test('maps message and code to error/code with a stable key order', () => {
+    const payload = buildErrorPayload({
+      code: ERROR_IDS.TASK_NOT_FOUND,
+      message: 'Task not found',
+    })
+
+    expect(Object.keys(payload)).toEqual(['error', 'code'])
+    expect(payload.error).toBe('Task not found')
+    expect(payload.code).toBe(ERROR_IDS.TASK_NOT_FOUND)
+  })
+
+  test('includes help and context only when provided', () => {
+    const payload = buildErrorPayload({
+      code: ERROR_IDS.INVALID_TASK_GID,
+      message: 'Invalid GID',
+      help: 'Run `asana task list` to find a valid GID',
+      context: { gid: 'abc' },
+    })
+
+    expect(Object.keys(payload)).toEqual(['error', 'code', 'help', 'context'])
+    expect(payload.help).toBe('Run `asana task list` to find a valid GID')
+    expect(payload.context).toEqual({ gid: 'abc' })
+  })
+
+  test('omits empty context object', () => {
+    const payload = buildErrorPayload({
+      code: ERROR_IDS.API_ERROR,
+      message: 'boom',
+      context: {},
+    })
+
+    expect(Object.keys(payload)).toEqual(['error', 'code'])
+  })
+})
+
+describe('formatStructuredError', () => {
+  test('renders valid JSON with error and code keys', () => {
+    const out = formatStructuredError(
+      { code: ERROR_IDS.TASK_NOT_FOUND, message: 'Task not found' },
+      'json',
+    )
+    const parsed = JSON.parse(out)
+
+    expect(parsed.error).toBe('Task not found')
+    expect(parsed.code).toBe(ERROR_IDS.TASK_NOT_FOUND)
+  })
+
+  test('renders TOON containing the message and code', () => {
+    const out = formatStructuredError(
+      { code: ERROR_IDS.TASK_NOT_FOUND, message: 'Task not found' },
+      'toon',
+    )
+
+    expect(out).toContain('error')
+    expect(out).toContain('Task not found')
+    expect(out).toContain('code')
+    expect(out).toContain(ERROR_IDS.TASK_NOT_FOUND)
+  })
+})
+
+describe('emitError', () => {
+  test('writes a structured payload to stdout for json format', () => {
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+
+    emitError({ code: ERROR_IDS.TASK_NOT_FOUND, message: 'Task not found' }, 'json')
+
+    expect(err).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledTimes(1)
+    const firstCall = log.mock.calls[0]
+    expect(firstCall).toBeDefined()
+    const parsed = JSON.parse(String(firstCall?.[0]))
+    expect(parsed.code).toBe(ERROR_IDS.TASK_NOT_FOUND)
+
+    mock.restore()
+  })
+
+  test('writes colored human output to stderr for plain format', () => {
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+
+    emitError(
+      { code: ERROR_IDS.TASK_NOT_FOUND, message: 'Task not found', help: 'Try again' },
+      'plain',
+    )
+
+    expect(log).not.toHaveBeenCalled()
+    expect(err).toHaveBeenCalled()
+    const joined = err.mock.calls.map(call => String(call[0])).join('\n')
+    expect(joined).toContain('Task not found')
+    expect(joined).toContain('Try again')
+
+    mock.restore()
+  })
+})

--- a/test/lib/axi-output.test.ts
+++ b/test/lib/axi-output.test.ts
@@ -110,6 +110,22 @@ describe('emitError', () => {
 
     mock.restore()
   })
+
+  test('renders object context values without [object Object] in plain output', () => {
+    spyOn(console, 'log').mockImplementation(() => {})
+    const err = spyOn(console, 'error').mockImplementation(() => {})
+
+    emitError(
+      { code: ERROR_IDS.NO_UPDATE_FIELDS, message: 'No fields', context: { fields: { name: 'x' } } },
+      'plain',
+    )
+
+    const joined = err.mock.calls.map(call => String(call[0])).join('\n')
+    expect(joined).not.toContain('[object Object]')
+    expect(joined).toContain('name')
+
+    mock.restore()
+  })
 })
 
 describe('emitResult', () => {

--- a/test/lib/axi-output.test.ts
+++ b/test/lib/axi-output.test.ts
@@ -11,6 +11,7 @@ import { ERROR_IDS } from '../../src/constants/errorIds'
 import {
   buildErrorPayload,
   emitError,
+  emitResult,
   formatStructuredError,
 } from '../../src/lib/axi-output'
 
@@ -106,6 +107,33 @@ describe('emitError', () => {
     const joined = err.mock.calls.map(call => String(call[0])).join('\n')
     expect(joined).toContain('Task not found')
     expect(joined).toContain('Try again')
+
+    mock.restore()
+  })
+})
+
+describe('emitResult', () => {
+  test('emits a structured payload to stdout for machine formats', () => {
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+
+    emitResult({ task: { gid: '1', status: 'success' } }, '✓ done', 'json')
+
+    expect(log).toHaveBeenCalledTimes(1)
+    const parsed = JSON.parse(String(log.mock.calls[0]?.[0]))
+    expect(parsed.task.gid).toBe('1')
+
+    mock.restore()
+  })
+
+  test('emits the human plain message for plain format', () => {
+    const log = spyOn(console, 'log').mockImplementation(() => {})
+
+    emitResult({ task: { gid: '1' } }, '✓ done', 'plain')
+
+    const out = String(log.mock.calls[0]?.[0])
+    expect(out).toContain('✓ done')
+    // The structured payload must not leak into plain output.
+    expect(out).not.toContain('gid')
 
     mock.restore()
   })

--- a/test/lib/axi-output.test.ts
+++ b/test/lib/axi-output.test.ts
@@ -6,6 +6,7 @@
  * human `plain` format keeps colored stderr output.
  */
 
+import * as nodeFs from 'node:fs'
 import { describe, expect, mock, spyOn, test } from 'bun:test'
 import { ERROR_IDS } from '../../src/constants/errorIds'
 import {
@@ -77,17 +78,19 @@ describe('formatStructuredError', () => {
 })
 
 describe('emitError', () => {
-  test('writes a structured payload to stdout for json format', () => {
-    const log = spyOn(console, 'log').mockImplementation(() => {})
+  test('writes a structured payload synchronously to stdout (fd 1) for json format', () => {
+    // Synchronous write (not console.log) so process.exit cannot truncate it
+    // when stdout is piped.
+    const writeSpy = spyOn(nodeFs, 'writeSync').mockImplementation(() => 0)
     const err = spyOn(console, 'error').mockImplementation(() => {})
 
     emitError({ code: ERROR_IDS.TASK_NOT_FOUND, message: 'Task not found' }, 'json')
 
     expect(err).not.toHaveBeenCalled()
-    expect(log).toHaveBeenCalledTimes(1)
-    const firstCall = log.mock.calls[0]
-    expect(firstCall).toBeDefined()
-    const parsed = JSON.parse(String(firstCall?.[0]))
+    expect(writeSpy).toHaveBeenCalledTimes(1)
+    const call = writeSpy.mock.calls[0]
+    expect(call?.[0]).toBe(1)
+    const parsed = JSON.parse(String(call?.[1]))
     expect(parsed.code).toBe(ERROR_IDS.TASK_NOT_FOUND)
 
     mock.restore()

--- a/test/lib/error-handler.test.ts
+++ b/test/lib/error-handler.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Error-handler tests.
+ *
+ * `translateAsanaError` is the pure mapping from a raw Asana/SDK/network error
+ * to a structured AxiError (stable code + actionable help). It is unit-tested
+ * here without touching the process-exit/emit side effects (AXI §6, ADR-003).
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { ERROR_IDS } from '../../src/constants/errorIds'
+import { translateAsanaError } from '../../src/lib/error-handler'
+
+const OP = 'Task creation'
+const CTX = { 'Task GID': '123' }
+
+describe('translateAsanaError', () => {
+  test('maps Asana SDK structured errors, preserving message and help', () => {
+    const error = { value: { errors: [{ message: 'Invalid request', help: 'Check the payload' }] } }
+    const result = translateAsanaError(error, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.API_ERROR)
+    expect(result.message).toContain('Invalid request')
+    expect(result.help).toBe('Check the payload')
+    expect(result.context).toEqual(CTX)
+  })
+
+  test('maps HTTP 401 to AUTH_FAILED with a re-auth hint', () => {
+    const result = translateAsanaError({ status: 401 }, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.AUTH_FAILED)
+    expect(result.help).toContain('auth login')
+  })
+
+  test('maps HTTP 403 to PERMISSION_DENIED', () => {
+    const result = translateAsanaError({ status: 403 }, OP, CTX)
+    expect(result.code).toBe(ERROR_IDS.PERMISSION_DENIED)
+  })
+
+  test('maps HTTP 404 to a not-found API error', () => {
+    const result = translateAsanaError({ status: 404 }, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.API_ERROR)
+    expect(result.message.toLowerCase()).toContain('not found')
+  })
+
+  test('maps HTTP 429 to RATE_LIMIT_EXCEEDED', () => {
+    const result = translateAsanaError({ status: 429 }, OP, CTX)
+    expect(result.code).toBe(ERROR_IDS.RATE_LIMIT_EXCEEDED)
+  })
+
+  test('maps HTTP 5xx to an API server error', () => {
+    const result = translateAsanaError({ status: 503 }, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.API_ERROR)
+    expect(result.message.toLowerCase()).toContain('server')
+  })
+
+  test('maps network errors to NETWORK_ERROR', () => {
+    const result = translateAsanaError({ code: 'ENOTFOUND' }, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.NETWORK_ERROR)
+    expect(result.message.toLowerCase()).toContain('network')
+  })
+
+  test('maps unknown errors to API_ERROR, preserving operation, context, and the raw message', () => {
+    const result = translateAsanaError({ message: 'boom' }, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.API_ERROR)
+    expect(result.message).toContain(OP)
+    // Original context is preserved and the underlying error detail is folded in.
+    expect(result.context).toMatchObject(CTX)
+    expect(result.context?.error).toBe('boom')
+  })
+
+  test('keeps context untouched when an unknown error carries no message', () => {
+    const result = translateAsanaError({}, OP, CTX)
+
+    expect(result.code).toBe(ERROR_IDS.API_ERROR)
+    expect(result.context).toEqual(CTX)
+  })
+})

--- a/test/lib/error-handler.test.ts
+++ b/test/lib/error-handler.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { ERROR_IDS } from '../../src/constants/errorIds'
-import { translateAsanaError } from '../../src/lib/error-handler'
+import { isNotFoundError, translateAsanaError } from '../../src/lib/error-handler'
 
 const OP = 'Task creation'
 const CTX = { 'Task GID': '123' }
@@ -77,5 +77,22 @@ describe('translateAsanaError', () => {
 
     expect(result.code).toBe(ERROR_IDS.API_ERROR)
     expect(result.context).toEqual(CTX)
+  })
+})
+
+describe('isNotFoundError', () => {
+  test('is true for an HTTP 404 error', () => {
+    expect(isNotFoundError({ status: 404 })).toBe(true)
+  })
+
+  test('is false for other HTTP statuses', () => {
+    expect(isNotFoundError({ status: 403 })).toBe(false)
+    expect(isNotFoundError({ status: 500 })).toBe(false)
+  })
+
+  test('is false for network and unknown errors', () => {
+    expect(isNotFoundError({ code: 'ENOTFOUND' })).toBe(false)
+    expect(isNotFoundError({})).toBe(false)
+    expect(isNotFoundError(null)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Makes the Asana CLI's error output **agent-readable** (AXI §6). When `--format` is
`toon` or `json`, failures are now emitted as a **structured payload to stdout**
(`error` / `code` / `help` / `context`) instead of colored text on stderr, so
agents invoking the CLI over shell can actually observe *why* a command failed.

The human `plain` path is **unchanged** and remains the default, so this is
backward-compatible — a **semver-minor** change (ADR-003, decision D2).

This is **Phase 1** of the AXI / Agent-DX adoption roadmap. No new runtime
dependency: it reuses the existing `ERROR_IDS` registry and `encodeToon`.

## What's included

- **`src/lib/axi-output.ts`** — new format-aware output boundary: pure
  `buildErrorPayload` / `formatStructuredError` + `emitError` (toon/json → stdout,
  plain → chalk stderr).
- **`error-handler.ts`** — pure `translateAsanaError` (Asana SDK / HTTP / network /
  unknown → stable code + actionable help) wired into a format-aware
  `handleAsanaError(..., format = 'plain')`.
- **Idempotent delete** — `task delete` on an already-gone task is now a no-op
  success (exit 0) via the pure `isNotFoundError` helper (AXI §6 idempotency).
- **Type tightening** — `ValidationError.errorId` narrowed `string` → `ErrorId`.
- **`task` command wiring** — all 7 error-path handlers thread the selected format.
- **Docs** — ADR-003 (error model, exit codes 0/1/2), ADR-004 (home view, formatter
  boundary), and `AXI-ADOPTION.md` (gap matrix, Agent-DX scorecard, phased plan).

## Exit-code policy (D5)

`0` success / idempotent no-op · `1` error · `2` usage error (reserved; enforced in
a later increment).

## Testing

- TDD throughout (Red → Green → Refactor); structural and behavioral commits kept
  separate.
- New unit tests: `test/lib/axi-output.test.ts`, `test/lib/error-handler.test.ts`.
- Full suite green: **354 pass**, 0 fail. `bunx tsc --noEmit` clean for all changed
  files (pre-existing errors in `oauth.test`/`self-update.test`/`batch.ts`/e2e are
  unrelated). ESLint clean.

## Follow-ups (tracked in `dev-docs/AXI-ADOPTION.md`)

- Roll format threading out to the other 15 command files (~44 `handleAsanaError`
  sites). Command unit tests are structural, so the wiring is low-regression-risk.
- Make the `ValidationError` path format-aware (stop printing in `validators.ts`;
  emit at the command boundary).
- Enforce exit code `2` for usage errors.
- Phase 2+ (empty states, counts, `--fields`, home view, session hook) and
  Agent-DX Phases 6–8 (raw payload, introspection, `--dry-run`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements AXI §6 Phase 1 with structured, agent-readable errors on stdout for `--format` `toon`/`json` (including validation), while `plain` stays unchanged. Adds idempotent `task delete`, structured success for `task complete`/`delete`, and threads format-aware handling across all task subcommands; structured errors are flushed synchronously to avoid truncation.

- **New Features**
  - Structured errors for `toon`/`json` with `error`, `code`, `help`, `context`.
  - Structured success for `task complete`/`delete` via `emitResult`; 404 delete → no‑op (exit 0).
  - Exit codes: 0 success/no‑op, 1 error (2 reserved for usage).

- **Refactors**
  - New `src/lib/axi-output.ts` and pure `translateAsanaError`; all task error paths pass `getOutputFormat(...)`.
  - Machine-format errors use synchronous stdout writes to avoid truncation before `process.exit`.
  - Tightened `ValidationError.errorId` and `AxiError.code` to `ErrorId`; plain error context uses `util.inspect`. Docs: ADR‑003, ADR‑004, adoption plan; added unit tests.

<sup>Written for commit c218dd0e18f321e6e324e5c8f76a03f2566c5e29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AXI structured output for agent automation: with `--format json`/`--format toon`, errors are machine-readable on stdout; `plain` stays human-friendly on stderr.
  * Validation and API errors are formatter-aware across task subcommands, with a clarified exit-code policy.
* **Bug Fixes**
  * `task delete` is idempotent: “already deleted” now returns a success no-op.
* **Documentation**
  * Added an “AXI Adoption Plan” roadmap and new ADRs for AXI conventions and the home view/output formatting boundary.
* **Tests**
  * Added Bun coverage for structured error/result rendering and error translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->