### PR TITLE
feat(auth): support brokered auth for sandbox egress

### DIFF
--- a/dev-docs/adr/005-brokered-auth-sandbox-egress.md
+++ b/dev-docs/adr/005-brokered-auth-sandbox-egress.md
@@ -1,0 +1,163 @@
+# ADR-005: Brokered Authentication for Sandbox Egress
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-25
+
+## Context
+
+Agent sandboxes increasingly run CLIs under an **egress credential-brokering**
+model so that an untrusted workload can authenticate to an external service
+*without ever holding the secret*. Two representative implementations:
+
+- **Vercel Sandbox — credentials brokering**
+  ([docs](https://vercel.com/docs/sandbox/concepts/firewall#credentials-brokering)):
+  the firewall matches egress by SNI, **terminates TLS** with a per-sandbox CA
+  (auto-trusted via standard env vars), and injects credentials into matching
+  requests. The secret never enters the sandbox scope.
+- **Cloudflare Sandbox — outbound handlers**
+  ([docs](https://developers.cloudflare.com/sandbox/guides/outbound-traffic/)):
+  a TPROXY sidecar transparently routes egress to an outbound handler running
+  *outside* the sandbox, which does `headers.set(...)` to attach the credential
+  before forwarding upstream. An ephemeral CA is auto-trusted.
+
+Despite different surface APIs, both are the **same pattern**: transparent
+network interception + TLS termination with an auto-trusted CA; the workload
+sends an *unauthenticated (or placeholder)* request to the **real upstream host**,
+and a broker living outside the sandbox injects the `Authorization` header. This
+is **not** an `HTTP_PROXY` forward-proxy model.
+
+### Relevant facts about the current CLI
+
+- `initializeApiClient()` (`src/lib/asana-client.ts:18-45`) **throws** when
+  `config.accessToken` is missing, and **always** sets
+  `token.accessToken = config.accessToken`, emitting `Authorization: Bearer <token>`.
+- It reads `loadConfig()` directly and **ignores** `ASANA_ACCESS_TOKEN`. The
+  env fallback in `getAccessToken()` (`src/lib/config.ts:35-38`,
+  `config?.accessToken || process.env.ASANA_ACCESS_TOKEN`) is **dead code** on the
+  client-init path.
+- The Asana SDK targets `https://app.asana.com/api/1.0` by default
+  (`node_modules/asana/src/ApiClient.js:36`), so brokers can already match by
+  host/SNI with no base-URL change.
+- OAuth refresh (`refreshTokenIfNeeded`, `src/lib/asana-client.ts:391-428`) only
+  runs for `authType === 'oauth'` **and** a present `refreshToken`; a PAT-style or
+  env placeholder token naturally skips refresh.
+- The SDK's HTTP layer is **superagent**, which does **not** honor
+  `HTTP_PROXY`/`HTTPS_PROXY` env vars — relevant only to a forward-proxy model,
+  which neither target system uses.
+
+The CLI is one small change away from being "broker-ready"; the gap is the hard
+requirement that a *real* token be present in local config.
+
+## Decision
+
+Make the CLI usable under brokered egress by **allowing it to run with a
+placeholder token sourced from the environment**, and document the broker
+contract. Concretely:
+
+### D1 — Source the access token through `getAccessToken()` (env fallback)
+
+`initializeApiClient()` resolves the token via `getAccessToken()` instead of
+reading `config.accessToken` directly. This activates the existing
+`ASANA_ACCESS_TOKEN` fallback so a sandbox can run:
+
+```
+ASANA_ACCESS_TOKEN=brokered asana task list -w <gid>
+```
+
+with **no `~/.asana-cli/config.json`**. The CLI emits `Authorization: Bearer brokered`,
+and the broker rule **overwrites** that header with the real secret.
+
+We send a placeholder Bearer rather than *no* header because Asana accepts only
+Bearer auth, and header **replacement** is the natural primitive in both targets
+(Cloudflare `headers.set`, Vercel header transform). A request with a present
+header is also unambiguous to match on.
+
+### D2 — Keep the real upstream host; no base-URL change required
+
+The CLI continues to target `app.asana.com`. Brokers match by host/SNI. We do
+**not** introduce client-side proxy configuration for the brokered path.
+
+### D3 — Brokered mode skips token refresh by construction
+
+No new "mode" flag. An env/PAT placeholder has no `refreshToken` and is not
+`authType === 'oauth'`, so `refreshTokenIfNeeded()` already returns `false`. The
+broker owns credential lifecycle; the CLI must never attempt to refresh a token
+it does not hold.
+
+### D4 — CA trust is the operator's responsibility, not the CLI's
+
+The CLI must **not** bundle a private CA or disable certificate validation. It
+relies on the sandbox auto-trusting its CA via standard env vars
+(`NODE_EXTRA_CA_CERTS` / `SSL_CERT_FILE`), which Bun honors and superagent
+inherits through `node:https`. This keeps TLS verification intact.
+
+### Out of scope (deferred)
+
+- An explicit `ASANA_BASE_URL` override (SDK supports `apiClient.basePath`) for
+  Vercel *requests-proxying* / self-hosted / test brokers.
+- Forward-proxy (`HTTPS_PROXY`) support, which would require injecting a proxy
+  agent into the SDK's `requestAgent`/`agent` override
+  (`node_modules/asana/src/ApiClient.js:438`).
+- An explicit `ASANA_AUTH_MODE=brokered` flag.
+
+These are additive and can land in a follow-up ADR if a forward-proxy or
+non-default-host deployment appears.
+
+## Consequences
+
+### Positive
+
+- The CLI runs under Vercel/Cloudflare credential brokering with a one-line
+  change; the real token never enters the sandbox.
+- Revives an already-documented env fallback (`ASANA_ACCESS_TOKEN`), making
+  local/CI usage (`ASANA_ACCESS_TOKEN=… asana …`) work without writing a config
+  file — a usability win beyond sandboxes.
+- No new dependency, no new flag, no change to the human-auth (`auth login`) path.
+
+### Negative
+
+- A placeholder token "works" only when a broker is actually configured to
+  overwrite the header; run outside a broker, `Bearer brokered` fails at Asana
+  with a 401. This is the intended failure mode but must be documented.
+- CA trust correctness depends on the runtime honoring `NODE_EXTRA_CA_CERTS`
+  under Bun + superagent; this is assumed and should be verified in a real
+  sandbox, not just unit tests.
+
+### Neutral
+
+- Precedence is config-file token first, then `ASANA_ACCESS_TOKEN`. Brokered
+  sandboxes simply ship no config file, so the env placeholder wins.
+- Forward-proxy and custom-host support remain open; this ADR deliberately scopes
+  to the transparent-interception model the two target systems use.
+
+## Alternatives Considered
+
+- **Send no `Authorization` header in brokered mode** — rejected: Asana is
+  Bearer-only, and "inject when absent" is a weaker, less portable broker
+  primitive than "replace when present"; a present header is also easier to match.
+- **New `ASANA_AUTH_MODE=brokered` flag** — rejected for now: adds surface area
+  for no behavior the env placeholder doesn't already give. Reconsider only if we
+  need to suppress the token-required check entirely.
+- **Client-side `HTTPS_PROXY` / proxy agent** — rejected for the target systems:
+  both use transparent interception, not forward proxying, and superagent ignores
+  proxy env vars anyway. Deferred to a follow-up if needed.
+
+## References
+
+- Vercel Sandbox firewall — credentials brokering:
+  <https://vercel.com/docs/sandbox/concepts/firewall#credentials-brokering>
+- Cloudflare Sandbox — outbound traffic:
+  <https://developers.cloudflare.com/sandbox/guides/outbound-traffic/>
+- ADR-003: AXI Agent eXperience Conventions (`./003-axi-agent-experience.md`)
+- Code: `src/lib/asana-client.ts` (`initializeApiClient`),
+  `src/lib/config.ts` (`getAccessToken`),
+  `node_modules/asana/src/ApiClient.js` (`basePath`, `requestAgent`)
+
+## Related Issues
+
+- #TBD: Brokered auth — source access token via `ASANA_ACCESS_TOKEN` env fallback

--- a/dev-docs/adr/005-brokered-auth-sandbox-egress.md
+++ b/dev-docs/adr/005-brokered-auth-sandbox-egress.md
@@ -65,7 +65,7 @@ contract. Concretely:
 reading `config.accessToken` directly. This activates the existing
 `ASANA_ACCESS_TOKEN` fallback so a sandbox can run:
 
-```
+```sh
 ASANA_ACCESS_TOKEN=brokered asana task list -w <gid>
 ```
 

--- a/dev-docs/adr/README.md
+++ b/dev-docs/adr/README.md
@@ -14,6 +14,7 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 | [002](./002-toon-output-format.md) | TOON Output Format for CLI | Proposed | 2025-10-30 |
 | [003](./003-axi-agent-experience.md) | AXI (Agent eXperience Interface) Conventions | Accepted | 2026-06-23 |
 | [004](./004-axi-home-view-and-formatter.md) | AXI Home View and Output-Formatter Boundary | Accepted | 2026-06-23 |
+| [005](./005-brokered-auth-sandbox-egress.md) | Brokered Authentication for Sandbox Egress | Proposed | 2026-06-25 |
 
 ## ADR Template
 

--- a/src/lib/asana-client.ts
+++ b/src/lib/asana-client.ts
@@ -25,11 +25,12 @@ function initializeApiClient(): typeof Asana.ApiClient.instance {
   // Resolve the token via getAccessToken() so the ASANA_ACCESS_TOKEN env
   // fallback is honored. This enables brokered-egress sandboxes (ADR-005) to
   // run with a placeholder token while a broker injects the real credential.
-  const accessToken = getAccessToken()
+  // Pass the already-loaded config to avoid a second readFileSync.
+  const accessToken = getAccessToken(config)
 
   if (!accessToken) {
     throw new Error(
-      'Asana access token not found. Please run "asana auth login" first.',
+      'Asana access token not found. Set ASANA_ACCESS_TOKEN or run "asana auth login" first.',
     )
   }
 

--- a/src/lib/asana-client.ts
+++ b/src/lib/asana-client.ts
@@ -1,5 +1,5 @@
 import Asana from 'asana'
-import { loadConfig, saveConfig } from './config'
+import { getAccessToken, loadConfig, saveConfig } from './config'
 import { refreshAccessToken } from './oauth'
 
 let apiClientInstance: typeof Asana.ApiClient.instance | null = null
@@ -22,14 +22,19 @@ function initializeApiClient(): typeof Asana.ApiClient.instance {
 
   const config = loadConfig()
 
-  if (!config || !config.accessToken) {
+  // Resolve the token via getAccessToken() so the ASANA_ACCESS_TOKEN env
+  // fallback is honored. This enables brokered-egress sandboxes (ADR-005) to
+  // run with a placeholder token while a broker injects the real credential.
+  const accessToken = getAccessToken()
+
+  if (!accessToken) {
     throw new Error(
       'Asana access token not found. Please run "asana auth login" first.',
     )
   }
 
   // Check if OAuth token is expired and refresh if needed
-  if (config.authType === 'oauth' && config.expiresAt && config.refreshToken) {
+  if (config?.authType === 'oauth' && config.expiresAt && config.refreshToken) {
     const isExpired = Date.now() >= config.expiresAt
 
     if (isExpired) {
@@ -39,7 +44,7 @@ function initializeApiClient(): typeof Asana.ApiClient.instance {
 
   apiClientInstance = Asana.ApiClient.instance
   const token = apiClientInstance.authentications.token
-  token.accessToken = config.accessToken
+  token.accessToken = accessToken
 
   return apiClientInstance
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,7 +32,6 @@ export function loadConfig(): AsanaConfig | null {
   }
 }
 
-export function getAccessToken(): string | null {
-  const config = loadConfig()
+export function getAccessToken(config: AsanaConfig | null = loadConfig()): string | null {
   return config?.accessToken || process.env.ASANA_ACCESS_TOKEN || null
 }

--- a/test/lib/asana-client.test.ts
+++ b/test/lib/asana-client.test.ts
@@ -133,6 +133,28 @@ describe('asana-client module', () => {
 
       expect(() => getAsanaClient()).toThrow('Asana access token not found')
     })
+
+    test('falls through an empty config token to ASANA_ACCESS_TOKEN', () => {
+      // Empty config token is falsy, so the `|| env` chain must reach the env
+      // placeholder. Guards against a future `||` -> `??` refactor silently
+      // breaking brokered egress.
+      const config: AsanaConfig = { accessToken: '', authType: 'pat' }
+      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
+      process.env.ASANA_ACCESS_TOKEN = 'brokered'
+
+      getAsanaClient()
+
+      expect(Asana.ApiClient.instance.authentications.token.accessToken).toBe('brokered')
+    })
+
+    test('throws when config token is empty and no ASANA_ACCESS_TOKEN is set', () => {
+      const config: AsanaConfig = { accessToken: '', authType: 'pat' }
+      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
+
+      expect(() => getAsanaClient()).toThrow('Asana access token not found')
+    })
   })
 
   describe('refreshTokenIfNeeded', () => {

--- a/test/lib/asana-client.test.ts
+++ b/test/lib/asana-client.test.ts
@@ -2,8 +2,9 @@ import type { AsanaConfig } from '../../src/types'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import Asana from 'asana'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { refreshTokenIfNeeded, resetClient } from '../../src/lib/asana-client'
+import { getAsanaClient, refreshTokenIfNeeded, resetClient } from '../../src/lib/asana-client'
 
 const TEST_CONFIG_DIR = join(homedir(), '.asana-cli')
 const TEST_CONFIG_FILE = join(TEST_CONFIG_DIR, 'config.json')
@@ -21,6 +22,9 @@ describe('asana-client module', () => {
     // Set up OAuth credentials for tests
     process.env.ASANA_CLIENT_ID = 'test-client-id'
     process.env.ASANA_CLIENT_SECRET = 'test-client-secret'
+
+    // Brokered-egress env token must not leak between tests
+    delete process.env.ASANA_ACCESS_TOKEN
   })
 
   afterEach(() => {
@@ -30,6 +34,7 @@ describe('asana-client module', () => {
     }
     delete process.env.ASANA_CLIENT_ID
     delete process.env.ASANA_CLIENT_SECRET
+    delete process.env.ASANA_ACCESS_TOKEN
 
     // Reset client after each test
     resetClient()
@@ -98,6 +103,35 @@ describe('asana-client module', () => {
 
       const saved = JSON.parse(readFileSync(TEST_CONFIG_FILE, 'utf-8'))
       expect(saved.expiresAt).toBeLessThan(Date.now())
+    })
+  })
+
+  describe('getAsanaClient token resolution (ADR-005 brokered egress)', () => {
+    test('uses ASANA_ACCESS_TOKEN placeholder when no config file exists', () => {
+      // Brokered sandbox: no ~/.asana-cli/config.json, only an env placeholder.
+      // The broker overwrites the Authorization header downstream.
+      expect(existsSync(TEST_CONFIG_FILE)).toBe(false)
+      process.env.ASANA_ACCESS_TOKEN = 'brokered'
+
+      expect(() => getAsanaClient()).not.toThrow()
+      expect(Asana.ApiClient.instance.authentications.token.accessToken).toBe('brokered')
+    })
+
+    test('prefers config-file token over ASANA_ACCESS_TOKEN', () => {
+      const config: AsanaConfig = { accessToken: 'config-token', authType: 'pat' }
+      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
+      process.env.ASANA_ACCESS_TOKEN = 'env-token'
+
+      getAsanaClient()
+
+      expect(Asana.ApiClient.instance.authentications.token.accessToken).toBe('config-token')
+    })
+
+    test('throws when neither config file nor ASANA_ACCESS_TOKEN is present', () => {
+      expect(existsSync(TEST_CONFIG_FILE)).toBe(false)
+
+      expect(() => getAsanaClient()).toThrow('Asana access token not found')
     })
   })
 


### PR DESCRIPTION
## Summary

Enables Vercel/Cloudflare credential-brokering for sandbox egress by honoring the
`ASANA_ACCESS_TOKEN` environment variable as a fallback in `initializeApiClient()`.
When the env var is set (e.g. injected by a brokering proxy), the client uses it
instead of requiring a token to be passed at call time.

## Changes

- `src/lib/asana-client.ts` — `initializeApiClient()` reads `process.env.ASANA_ACCESS_TOKEN`
  as a fallback when no token argument is supplied
- `test/lib/asana-client.test.ts` — 3 new TDD tests covering the env-var fallback path
  (full suite: 360 pass / 0 fail)
- `dev-docs/adr/005-brokered-auth-sandbox-egress.md` — ADR-005 (status: Proposed) documenting
  the brokered-auth approach, trade-offs, and the open item that gates promotion to Accepted
- `dev-docs/adr/README.md` — ADR index updated with the new entry

## Test Plan

- [x] Unit tests added for env-var fallback (`bun test`)
- [x] Full suite passes (360/360) with no regressions
- [ ] CA-trust verification in a real Vercel/Cloudflare sandbox environment
  (this is the open item that gates ADR-005 → Accepted)

## Open / Out of Scope

The following related items are intentionally deferred to follow-up issues:

- `ASANA_BASE_URL` environment-variable override for sandbox base URL
- `HTTPS_PROXY` forward-proxy support
- `AUTH_MODE=brokered` explicit flag for clearer intent signaling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables brokered auth for sandbox egress (Vercel/Cloudflare) by letting the CLI use `ASANA_ACCESS_TOKEN` as a fallback during client init. This allows running with a placeholder token that a broker replaces, without local config.

- **New Features**
  - `initializeApiClient()` now resolves the token via `getAccessToken(config?)`, honoring `ASANA_ACCESS_TOKEN` (including when a config token is empty); passes the preloaded config to avoid another read; improves the missing-token error to suggest setting `ASANA_ACCESS_TOKEN`; OAuth refresh still only runs when config includes refresh data.
  - Added tests for env fallback, precedence over config, empty config token falling through to env, and the error when no token is available.
  - Added ADR-005 documenting the brokered egress approach and constraints; minor doc polish (shell fence).

<sup>Written for commit 9c6fb6c6fbd7fb808bb9268e757ca22404ed8747. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The CLI now resolves the Asana access token from the environment (ASANA_ACCESS_TOKEN) when a config token isn’t available, with config-token precedence when both exist.
  * Improved failure behavior by throwing a clear error when no token can be found (including when the config token is empty).

* **Documentation**
  * Added a new architecture note covering brokered authentication for sandbox egress.
  * Updated the ADR index to include the new note.

* **Tests**
  * Added coverage for the new token-resolution behavior and environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->