### PR TITLE
fix(auth): surface real errors in whoami instead of masking as not authenticated

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,4 +1,3 @@
-import type { OutputFormat } from '../utils/formatter'
 import asana from 'asana'
 import chalk from 'chalk'
 import { Command } from 'commander'
@@ -6,7 +5,7 @@ import { getAsanaClient, resetClient } from '../lib/asana-client'
 import { loadConfig, saveConfig } from '../lib/config'
 import { handleAsanaError } from '../lib/error-handler'
 import { startOAuthFlow } from '../lib/oauth'
-import { formatOutput } from '../utils/formatter'
+import { formatOutput, getOutputFormat } from '../utils/formatter'
 
 export function createAuthCommand(): Command {
   const auth = new Command('auth')
@@ -101,7 +100,7 @@ export function createAuthCommand(): Command {
     .description('Display current authenticated user')
     .action(async (options: any, command: Command) => {
       // Resolve format up front so it is available in the catch block too.
-      const format = (command.parent?.parent?.opts()?.format || 'toon') as OutputFormat
+      const format = getOutputFormat(command)
 
       try {
         const client = getAsanaClient()
@@ -137,8 +136,10 @@ export function createAuthCommand(): Command {
         console.log(output)
       }
       catch (error) {
-        // No stored credentials at all → keep the friendly login hint.
-        if (error instanceof Error && /access token not found/i.test(error.message)) {
+        // No stored credentials at all → keep the friendly login hint for humans.
+        // For machine formats (json/toon) fall through to handleAsanaError so the
+        // failure is emitted as structured output instead of a plain colored line.
+        if (format === 'plain' && error instanceof Error && error.message.includes('Asana access token not found')) {
           console.error(chalk.red('✗ Not authenticated. Run "asana auth login" first.'))
           process.exit(1)
         }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { getAsanaClient, resetClient } from '../lib/asana-client'
 import { loadConfig, saveConfig } from '../lib/config'
+import { handleAsanaError } from '../lib/error-handler'
 import { startOAuthFlow } from '../lib/oauth'
 import { formatOutput } from '../utils/formatter'
 
@@ -99,13 +100,13 @@ export function createAuthCommand(): Command {
     .command('whoami')
     .description('Display current authenticated user')
     .action(async (options: any, command: Command) => {
+      // Resolve format up front so it is available in the catch block too.
+      const format = (command.parent?.parent?.opts()?.format || 'toon') as OutputFormat
+
       try {
         const client = getAsanaClient()
         const user = await client.users.me()
         const config = loadConfig()
-
-        // Get format from parent command (root program)
-        const format = (command.parent?.parent?.opts()?.format || 'toon') as OutputFormat
 
         // Prepare user data for output
         const userData: any = {
@@ -135,9 +136,16 @@ export function createAuthCommand(): Command {
         const output = formatOutput(userData, { format, colors: process.stdout.isTTY })
         console.log(output)
       }
-      catch {
-        console.error(chalk.red('✗ Not authenticated. Run "asana auth login" first.'))
-        process.exit(1)
+      catch (error) {
+        // No stored credentials at all → keep the friendly login hint.
+        if (error instanceof Error && /access token not found/i.test(error.message)) {
+          console.error(chalk.red('✗ Not authenticated. Run "asana auth login" first.'))
+          process.exit(1)
+        }
+
+        // Otherwise surface the real failure (401, app-type restriction, network,
+        // etc.) instead of masking every error as "not authenticated".
+        handleAsanaError(error, 'Get current user', {}, format)
       }
     })
 

--- a/test/commands/auth-whoami.test.ts
+++ b/test/commands/auth-whoami.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { Command } from 'commander'
 import * as realClient from '../../src/lib/asana-client'
 import * as realErrorHandler from '../../src/lib/error-handler'
 
@@ -15,7 +16,10 @@ const REAL_ERROR_HANDLER = { ...realErrorHandler }
  * printed "✗ Not authenticated. Run \"asana auth login\" first." — masking the
  * actual cause (e.g. an Asana 400 "This endpoint requires an API app." or an
  * expired-token 401). It now routes failures through `handleAsanaError`, while
- * keeping the friendly hint only for the genuine missing-credentials case.
+ * keeping the friendly hint only for the genuine missing-credentials case in
+ * the human-readable `plain` format. Machine formats (json/toon) route the
+ * missing-credentials case through `handleAsanaError` too, so consumers receive
+ * structured output instead of a plain colored line.
  */
 describe('auth whoami error surfacing', () => {
   afterEach(() => {
@@ -64,7 +68,7 @@ describe('auth whoami error surfacing', () => {
     errorSpy.mockRestore()
   })
 
-  test('keeps the friendly login hint when no credentials are stored', async () => {
+  test('keeps the friendly login hint for plain format when no credentials are stored', async () => {
     mock.module('../../src/lib/asana-client', () => ({
       getAsanaClient: () => {
         throw new Error('Asana access token not found. Please run "asana auth login" first.')
@@ -82,16 +86,54 @@ describe('auth whoami error surfacing', () => {
       throw new Error('__exit__')
     }) as any)
 
+    // Mount auth under a root program that owns the global --format option so
+    // `getOutputFormat` resolves `plain` via optsWithGlobals().
+    const program = new Command()
+    program.option('-f, --format <type>', 'output format', 'toon')
     const { createAuthCommand } = await import('../../src/commands/auth')
-    const auth = createAuthCommand()
-    await expect(auth.parseAsync(['whoami'], { from: 'user' })).rejects.toThrow('__exit__')
+    program.addCommand(createAuthCommand())
+    await expect(
+      program.parseAsync(['--format', 'plain', 'auth', 'whoami'], { from: 'user' }),
+    ).rejects.toThrow('__exit__')
 
-    // Missing credentials → friendly hint, and NOT routed as an API error.
+    // Missing credentials in plain format → friendly hint, NOT routed as an API error.
     const printed = errorSpy.mock.calls.flat().join(' ')
     expect(printed).toContain('Not authenticated')
     expect(handled).toHaveLength(0)
 
     errorSpy.mockRestore()
     exitSpy.mockRestore()
+  })
+
+  test('routes missing credentials through handleAsanaError for machine formats (default toon)', async () => {
+    mock.module('../../src/lib/asana-client', () => ({
+      getAsanaClient: () => {
+        throw new Error('Asana access token not found. Please run "asana auth login" first.')
+      },
+      resetClient: () => {},
+    }))
+
+    const handled: any[] = []
+    mock.module('../../src/lib/error-handler', () => ({
+      handleAsanaError: (error: any) => {
+        handled.push(error)
+        throw new Error('__handled__')
+      },
+    }))
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+
+    const { createAuthCommand } = await import('../../src/commands/auth')
+    const auth = createAuthCommand()
+    // No --format → default 'toon' (machine format) → structured error path.
+    await expect(auth.parseAsync(['whoami'], { from: 'user' })).rejects.toThrow('__handled__')
+
+    expect(handled).toHaveLength(1)
+    expect(String((handled[0] as Error).message)).toContain('Asana access token not found')
+    // The plain friendly hint must NOT be printed for machine formats.
+    const printed = errorSpy.mock.calls.flat().join(' ')
+    expect(printed).not.toContain('Not authenticated')
+
+    errorSpy.mockRestore()
   })
 })

--- a/test/commands/auth-whoami.test.ts
+++ b/test/commands/auth-whoami.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import * as realClient from '../../src/lib/asana-client'
+import * as realErrorHandler from '../../src/lib/error-handler'
+
+// Bun's `mock.restore()` does NOT revert `mock.module()` registrations, so the
+// module mocks below would leak into later test files. Capture the real modules
+// by value at load time and re-install them once this file finishes.
+const REAL_CLIENT = { ...realClient }
+const REAL_ERROR_HANDLER = { ...realErrorHandler }
+
+/**
+ * Regression test for `asana auth whoami` error handling.
+ *
+ * `whoami` used a bare `catch {}` that discarded the real error and always
+ * printed "✗ Not authenticated. Run \"asana auth login\" first." — masking the
+ * actual cause (e.g. an Asana 400 "This endpoint requires an API app." or an
+ * expired-token 401). It now routes failures through `handleAsanaError`, while
+ * keeping the friendly hint only for the genuine missing-credentials case.
+ */
+describe('auth whoami error surfacing', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  afterAll(() => {
+    mock.module('../../src/lib/asana-client', () => REAL_CLIENT)
+    mock.module('../../src/lib/error-handler', () => REAL_ERROR_HANDLER)
+  })
+
+  test('routes real API failures through handleAsanaError, not the generic "Not authenticated" message', async () => {
+    // Asana rejects /users/me for non-API apps with a structured 400 error.
+    const asanaError = {
+      value: { errors: [{ message: 'This endpoint requires an API app.', help: 'https://developers.asana.com/docs/errors' }] },
+    }
+
+    mock.module('../../src/lib/asana-client', () => ({
+      getAsanaClient: () => ({ users: { me: async () => { throw asanaError } } }),
+      resetClient: () => {},
+    }))
+
+    // Capture the error routed to handleAsanaError; throw to stop the action
+    // (the real implementation calls process.exit).
+    const handled: any[] = []
+    mock.module('../../src/lib/error-handler', () => ({
+      handleAsanaError: (error: any) => {
+        handled.push(error)
+        throw new Error('__handled__')
+      },
+    }))
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+
+    const { createAuthCommand } = await import('../../src/commands/auth')
+    const auth = createAuthCommand()
+    await expect(auth.parseAsync(['whoami'], { from: 'user' })).rejects.toThrow('__handled__')
+
+    // The real Asana error reached the centralized handler...
+    expect(handled).toHaveLength(1)
+    expect(JSON.stringify(handled[0])).toContain('This endpoint requires an API app.')
+    // ...and the generic masking message was NOT printed.
+    const printed = errorSpy.mock.calls.flat().join(' ')
+    expect(printed).not.toContain('Not authenticated')
+
+    errorSpy.mockRestore()
+  })
+
+  test('keeps the friendly login hint when no credentials are stored', async () => {
+    mock.module('../../src/lib/asana-client', () => ({
+      getAsanaClient: () => {
+        throw new Error('Asana access token not found. Please run "asana auth login" first.')
+      },
+      resetClient: () => {},
+    }))
+
+    const handled: any[] = []
+    mock.module('../../src/lib/error-handler', () => ({
+      handleAsanaError: (error: any) => { handled.push(error) },
+    }))
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {})
+    const exitSpy = spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('__exit__')
+    }) as any)
+
+    const { createAuthCommand } = await import('../../src/commands/auth')
+    const auth = createAuthCommand()
+    await expect(auth.parseAsync(['whoami'], { from: 'user' })).rejects.toThrow('__exit__')
+
+    // Missing credentials → friendly hint, and NOT routed as an API error.
+    const printed = errorSpy.mock.calls.flat().join(' ')
+    expect(printed).toContain('Not authenticated')
+    expect(handled).toHaveLength(0)
+
+    errorSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary

`asana auth whoami` used a bare `catch {}` that discarded the actual error and always printed `✗ Not authenticated. Run "asana auth login" first.`, masking the real cause (e.g. Asana 400 "This endpoint requires an API app.", or an expired-token 401).

## Changes
- Resolve output `format` up front in the `whoami` action so it is available in the catch block.
- Route failures through the centralized `handleAsanaError` (`src/lib/error-handler.ts`), consistent with all other commands — surfacing the real Asana status/message and the proper 401 re-auth hint.
- Keep the friendly `Not authenticated` hint only for the genuine missing-credentials case.
- Add regression test `test/commands/auth-whoami.test.ts`.

## Verification
- `bun test test/` → 359 pass.
- Smoke (isolated HOME, bogus token): `auth whoami` now prints `✗ Authentication failed / Your access token may have expired...` instead of the generic message.

Fixes #43

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show real Asana errors in `asana auth whoami` instead of always printing “Not authenticated,” by routing failures through centralized `handleAsanaError`. Keep the friendly login hint only for `plain` output when no credentials exist. Fixes #43.

- **Bug Fixes**
  - Resolve output format early via `getOutputFormat(command)` (no brittle parent opts chain).
  - Surface real API failures through `handleAsanaError`; for missing credentials show the hint only in `plain`, and route machine formats (e.g., `toon`/JSON) to structured errors; detect the missing-token case with `String.includes`.
  - Add regression tests in `test/commands/auth-whoami.test.ts`.

<sup>Written for commit d720983b1f39a9d7cdf9cc90c44647b1578e0595. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `asana auth whoami` error handling by consistently rendering failures in the selected output format.
  * Kept the “Run `asana auth login` first” reminder only for the `plain` format when credentials are missing, while other failure types now show the more relevant error instead of a generic fallback.
* **Tests**
  * Added/extended regression tests to verify error surfacing across multiple failure modes and output formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->