### PR TITLE
feat(auth): configurable OAuth redirect port and app-type flow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,19 @@ bun run dev --help
 # Using Personal Access Token (recommended)
 asana auth login --token YOUR_TOKEN
 
-# Using OAuth 2.0
+# Using OAuth 2.0 — choose the flow that matches your Asana app type:
+#   Web / server app (a loopback redirect URL can be registered):
 asana auth login
+#   Command-line app (OOB only), or headless / CI:
+asana auth login --no-browser
 ```
+
+OAuth requires `ASANA_CLIENT_ID` and `ASANA_CLIENT_SECRET` (create an app at
+<https://app.asana.com/0/my-apps>). The browser flow redirects to
+`http://localhost:8080/callback` — this exact URL must be registered on the app;
+change the port with `--redirect-port <port>` (or `ASANA_OAUTH_REDIRECT_PORT`).
+A `redirect_uri does not match` error means your app is a **command-line app** —
+use `--no-browser`.
 
 ### Manage Tasks
 

--- a/skills/asana-cli/references/commands.md
+++ b/skills/asana-cli/references/commands.md
@@ -46,11 +46,19 @@ object including its `gid` and `permalink_url`.
   - `--token <token>` — use Personal Access Token (recommended; from https://app.asana.com/0/my-apps)
   - `-w, --workspace <workspace>` — set default workspace at login
   - `--scope <scopes>` — OAuth scopes, space-separated
-  - `--no-browser` — copy-paste flow for headless/CI
+  - `--no-browser` — copy-paste (out-of-band) flow for headless/CI and **command-line app** types
+  - `--redirect-port <port>` — local port for the browser redirect (default 8080); must match the URL registered on the Asana app
 - `asana auth logout` — remove stored credentials
 - `asana auth whoami` — show current user, auth type, default workspace
 
 OAuth requires env vars `ASANA_CLIENT_ID` and `ASANA_CLIENT_SECRET`.
+
+Pick the flow by Asana app type:
+
+- **Web / server app** (a loopback redirect URL can be registered) → `asana auth login` (browser flow, redirects to `http://localhost:8080/callback`).
+- **Command-line app** (only accepts the OOB redirect `urn:ietf:wg:oauth:2.0:oob`), or headless / CI → `asana auth login --no-browser`.
+
+An `invalid_request: redirect_uri does not match` error means the app is a command-line app — re-run with `--no-browser`. Override the browser-flow port with `--redirect-port <port>` or `ASANA_OAUTH_REDIRECT_PORT`.
 
 ## workspace
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -52,7 +52,15 @@ export function createAuthCommand(): Command {
           console.log(chalk.gray('  Docs: https://developers.asana.com/docs/getting-started-with-asana-oauth\n'))
 
           const scopes = options.scope ? options.scope.trim().split(/\s+/) : undefined
-          const redirectPort = options.redirectPort ? Number.parseInt(options.redirectPort, 10) : undefined
+          // Fail fast on a malformed --redirect-port instead of silently
+          // falling back to the default and binding an unexpected port.
+          let redirectPort: number | undefined
+          if (options.redirectPort !== undefined) {
+            redirectPort = Number(options.redirectPort)
+            if (!Number.isInteger(redirectPort) || redirectPort < 1 || redirectPort > 65535) {
+              throw new Error(`Invalid --redirect-port "${options.redirectPort}"; expected an integer between 1 and 65535.`)
+            }
+          }
           const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false, redirectPort })
 
           // Calculate expiration time
@@ -81,7 +89,7 @@ export function createAuthCommand(): Command {
         console.error(message)
         // A redirect_uri mismatch almost always means the app is a command-line
         // app type, which only accepts the out-of-band flow.
-        if (/redirect_uri|invalid_request/i.test(message)) {
+        if (/redirect_uri/i.test(message)) {
           console.error(chalk.yellow('  Hint: If your Asana app is a "command-line app", re-run with --no-browser.'))
         }
         process.exit(1)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -7,6 +7,19 @@ import { loadConfig, saveConfig } from '../lib/config'
 import { startOAuthFlow } from '../lib/oauth'
 import { formatOutput } from '../utils/formatter'
 
+/**
+ * Parse and validate a redirect-port value from a CLI flag or env var. Throws a
+ * clear error when the value is not an integer in the valid TCP range. Line
+ * breaks are stripped from the echoed value to avoid log injection (S5145).
+ */
+function parseRedirectPort(raw: string, source: string): number {
+  const port = Number(raw)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid ${source} "${raw.replace(/[\r\n]/g, '')}"; expected an integer between 1 and 65535.`)
+  }
+  return port
+}
+
 export function createAuthCommand(): Command {
   const auth = new Command('auth')
     .description('Manage Asana authentication')
@@ -52,17 +65,15 @@ export function createAuthCommand(): Command {
           console.log(chalk.gray('  Docs: https://developers.asana.com/docs/getting-started-with-asana-oauth\n'))
 
           const scopes = options.scope ? options.scope.trim().split(/\s+/) : undefined
-          // Fail fast on a malformed --redirect-port instead of silently
-          // falling back to the default and binding an unexpected port.
+          // Fail fast on a malformed port from either source instead of
+          // silently falling back to the default and binding an unexpected
+          // port. The CLI flag takes precedence over the env var.
           let redirectPort: number | undefined
           if (options.redirectPort !== undefined) {
-            redirectPort = Number(options.redirectPort)
-            if (!Number.isInteger(redirectPort) || redirectPort < 1 || redirectPort > 65535) {
-              // Strip line breaks from the echoed user value to avoid log
-              // injection when this message is later logged (SonarCloud S5145).
-              const shownPort = options.redirectPort.replace(/[\r\n]/g, '')
-              throw new Error(`Invalid --redirect-port "${shownPort}"; expected an integer between 1 and 65535.`)
-            }
+            redirectPort = parseRedirectPort(options.redirectPort, '--redirect-port')
+          }
+          else if (process.env.ASANA_OAUTH_REDIRECT_PORT !== undefined) {
+            redirectPort = parseRedirectPort(process.env.ASANA_OAUTH_REDIRECT_PORT, 'ASANA_OAUTH_REDIRECT_PORT')
           }
           const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false, redirectPort })
 

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -9,13 +9,13 @@ import { formatOutput } from '../utils/formatter'
 
 /**
  * Parse and validate a redirect-port value from a CLI flag or env var. Throws a
- * clear error when the value is not an integer in the valid TCP range. Line
- * breaks are stripped from the echoed value to avoid log injection (S5145).
+ * clear error when the value is not an integer in the valid TCP range. The
+ * echoed value is sanitized at the logging sink (see the catch block below).
  */
 function parseRedirectPort(raw: string, source: string): number {
   const port = Number(raw)
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    throw new Error(`Invalid ${source} "${raw.replace(/[\r\n]/g, '')}"; expected an integer between 1 and 65535.`)
+    throw new Error(`Invalid ${source} "${raw}"; expected an integer between 1 and 65535.`)
   }
   return port
 }
@@ -99,7 +99,9 @@ export function createAuthCommand(): Command {
       }
       catch (error) {
         console.error(chalk.red('✗ Authentication failed:'))
-        const message = error instanceof Error ? error.message : String(error)
+        // Strip line breaks before logging so user-controlled values embedded
+        // in an error message cannot forge log lines (SonarCloud S5145).
+        const message = (error instanceof Error ? error.message : String(error)).replace(/[\r\n]+/g, ' ')
         console.error(message)
         // A redirect_uri mismatch almost always means the app is a command-line
         // app type, which only accepts the out-of-band flow. Asana surfaces this

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -58,7 +58,10 @@ export function createAuthCommand(): Command {
           if (options.redirectPort !== undefined) {
             redirectPort = Number(options.redirectPort)
             if (!Number.isInteger(redirectPort) || redirectPort < 1 || redirectPort > 65535) {
-              throw new Error(`Invalid --redirect-port "${options.redirectPort}"; expected an integer between 1 and 65535.`)
+              // Strip line breaks from the echoed user value to avoid log
+              // injection when this message is later logged (SonarCloud S5145).
+              const shownPort = options.redirectPort.replace(/[\r\n]/g, '')
+              throw new Error(`Invalid --redirect-port "${shownPort}"; expected an integer between 1 and 65535.`)
             }
           }
           const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false, redirectPort })
@@ -88,8 +91,10 @@ export function createAuthCommand(): Command {
         const message = error instanceof Error ? error.message : String(error)
         console.error(message)
         // A redirect_uri mismatch almost always means the app is a command-line
-        // app type, which only accepts the out-of-band flow.
-        if (/redirect_uri/i.test(message)) {
+        // app type, which only accepts the out-of-band flow. Asana surfaces this
+        // through the callback as `OAuth error: invalid_request` (no redirect_uri
+        // token), so match both shapes.
+        if (/redirect_uri|invalid_request/i.test(message)) {
           console.error(chalk.yellow('  Hint: If your Asana app is a "command-line app", re-run with --no-browser.'))
         }
         process.exit(1)

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -18,6 +18,7 @@ export function createAuthCommand(): Command {
     .option('-w, --workspace <workspace>', 'Default workspace ID')
     .option('--scope <scopes>', 'OAuth scopes, space-separated (e.g. "tasks:read projects:read")')
     .option('--no-browser', 'Use copy-paste flow instead of opening browser (for headless/CI environments)')
+    .option('--redirect-port <port>', 'Local port for the OAuth browser redirect (default 8080); must match the URL registered on the Asana app')
     .action(async (options) => {
       try {
         if (options.token) {
@@ -51,7 +52,8 @@ export function createAuthCommand(): Command {
           console.log(chalk.gray('  Docs: https://developers.asana.com/docs/getting-started-with-asana-oauth\n'))
 
           const scopes = options.scope ? options.scope.trim().split(/\s+/) : undefined
-          const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false })
+          const redirectPort = options.redirectPort ? Number.parseInt(options.redirectPort, 10) : undefined
+          const tokenResponse = await startOAuthFlow({ scopes, oob: options.browser === false, redirectPort })
 
           // Calculate expiration time
           const expiresAt = Date.now() + (tokenResponse.expires_in * 1000)
@@ -75,7 +77,13 @@ export function createAuthCommand(): Command {
       }
       catch (error) {
         console.error(chalk.red('✗ Authentication failed:'))
-        console.error(error instanceof Error ? error.message : error)
+        const message = error instanceof Error ? error.message : String(error)
+        console.error(message)
+        // A redirect_uri mismatch almost always means the app is a command-line
+        // app type, which only accepts the out-of-band flow.
+        if (/redirect_uri|invalid_request/i.test(message)) {
+          console.error(chalk.yellow('  Hint: If your Asana app is a "command-line app", re-run with --no-browser.'))
+        }
         process.exit(1)
       }
     })

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -8,11 +8,57 @@ import open from 'open'
 const OAUTH_CONFIG = {
   authUrl: 'https://app.asana.com/-/oauth_authorize',
   tokenUrl: 'https://app.asana.com/-/oauth_token',
-  redirectUri: 'http://localhost:8080/callback',
+  defaultRedirectPort: 8080,
+  redirectPath: '/callback',
   defaultScopes: 'default',
 }
 
 const OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
+
+/**
+ * Resolve the loopback redirect port for the browser flow:
+ * explicit option → `ASANA_OAUTH_REDIRECT_PORT` env → default 8080. Pure.
+ *
+ * The resulting redirect URL must be registered on the Asana OAuth app.
+ */
+export function resolveRedirectPort(port?: number): number {
+  if (port !== undefined && Number.isInteger(port) && port > 0) {
+    return port
+  }
+  const envPort = Number(process.env.ASANA_OAUTH_REDIRECT_PORT)
+  if (Number.isInteger(envPort) && envPort > 0) {
+    return envPort
+  }
+  return OAUTH_CONFIG.defaultRedirectPort
+}
+
+/**
+ * Build the loopback redirect URI (e.g. http://localhost:8080/callback). Pure.
+ */
+export function buildLoopbackRedirectUri(port: number): string {
+  return `http://localhost:${port}${OAUTH_CONFIG.redirectPath}`
+}
+
+/**
+ * Build the Asana authorize URL with PKCE (S256). Pure.
+ */
+export function buildAuthorizeUrl(params: {
+  clientId: string
+  redirectUri: string
+  scope: string
+  state: string
+  codeChallenge: string
+}): string {
+  const authUrl = new URL(OAUTH_CONFIG.authUrl)
+  authUrl.searchParams.set('client_id', params.clientId)
+  authUrl.searchParams.set('redirect_uri', params.redirectUri)
+  authUrl.searchParams.set('response_type', 'code')
+  authUrl.searchParams.set('state', params.state)
+  authUrl.searchParams.set('scope', params.scope)
+  authUrl.searchParams.set('code_challenge', params.codeChallenge)
+  authUrl.searchParams.set('code_challenge_method', 'S256')
+  return authUrl.toString()
+}
 
 export interface OAuthTokenResponse {
   access_token: string
@@ -24,6 +70,8 @@ export interface OAuthTokenResponse {
 export interface OAuthFlowOptions {
   scopes?: string[]
   oob?: boolean
+  /** Local port for the browser-flow redirect (default 8080, or env). */
+  redirectPort?: number
 }
 
 function base64urlEncode(bytes: Uint8Array): string {
@@ -79,16 +127,10 @@ export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OA
   const state = generateSecureState()
   const { codeVerifier, codeChallenge } = await generatePKCE()
   const scopeStr = options.scopes?.join(' ') || OAUTH_CONFIG.defaultScopes
-  const redirectUri = options.oob ? OOB_REDIRECT_URI : OAUTH_CONFIG.redirectUri
+  const port = resolveRedirectPort(options.redirectPort)
+  const redirectUri = options.oob ? OOB_REDIRECT_URI : buildLoopbackRedirectUri(port)
 
-  const authUrl = new URL(OAUTH_CONFIG.authUrl)
-  authUrl.searchParams.set('client_id', clientId)
-  authUrl.searchParams.set('redirect_uri', redirectUri)
-  authUrl.searchParams.set('response_type', 'code')
-  authUrl.searchParams.set('state', state)
-  authUrl.searchParams.set('scope', scopeStr)
-  authUrl.searchParams.set('code_challenge', codeChallenge)
-  authUrl.searchParams.set('code_challenge_method', 'S256')
+  const authUrl = new URL(buildAuthorizeUrl({ clientId, redirectUri, scope: scopeStr, state, codeChallenge }))
 
   if (options.oob) {
     return startOobFlow(authUrl, codeVerifier, clientId, clientSecret)
@@ -96,12 +138,13 @@ export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OA
 
   console.log(chalk.blue('Opening browser for authentication...'))
   console.log(chalk.gray(`If the browser doesn't open, visit: ${authUrl.toString()}`))
+  console.log(chalk.gray('  If your Asana app is a "command-line app", re-run with --no-browser.'))
 
   return new Promise((resolve, reject) => {
     const server = createServer(async (req, res) => {
-      const url = new URL(req.url || '', 'http://localhost:8080')
+      const url = new URL(req.url || '', `http://localhost:${port}`)
 
-      if (url.pathname === '/callback') {
+      if (url.pathname === OAUTH_CONFIG.redirectPath) {
         const code = url.searchParams.get('code') || ''
         const returnedState = url.searchParams.get('state') || ''
         const error = url.searchParams.get('error') || ''
@@ -123,7 +166,7 @@ export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OA
         }
 
         try {
-          const token = await exchangeCodeForToken(code, clientId, clientSecret, OAUTH_CONFIG.redirectUri, codeVerifier)
+          const token = await exchangeCodeForToken(code, clientId, clientSecret, redirectUri, codeVerifier)
 
           res.writeHead(200, { 'Content-Type': 'text/html' })
           res.end('<h1>Authentication Successful!</h1><p>You can close this window and return to the terminal.</p>')
@@ -140,13 +183,13 @@ export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OA
       }
     })
 
-    server.listen(8080, () => {
+    server.listen(port, () => {
       console.log(chalk.gray('Waiting for authentication...'))
       open(authUrl.toString())
     })
 
     server.on('error', (err) => {
-      reject(new Error(`Failed to start local server: ${err.message}`))
+      reject(new Error(`Failed to start local server on port ${port}: ${err.message}. Try a different port with --redirect-port.`))
     })
   })
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -22,11 +22,11 @@ const OOB_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
  * The resulting redirect URL must be registered on the Asana OAuth app.
  */
 export function resolveRedirectPort(port?: number): number {
-  if (port !== undefined && Number.isInteger(port) && port > 0) {
+  if (port !== undefined && Number.isInteger(port) && port > 0 && port <= 65535) {
     return port
   }
   const envPort = Number(process.env.ASANA_OAUTH_REDIRECT_PORT)
-  if (Number.isInteger(envPort) && envPort > 0) {
+  if (Number.isInteger(envPort) && envPort > 0 && envPort <= 65535) {
     return envPort
   }
   return OAUTH_CONFIG.defaultRedirectPort
@@ -183,9 +183,16 @@ export async function startOAuthFlow(options: OAuthFlowOptions = {}): Promise<OA
       }
     })
 
-    server.listen(port, () => {
+    // Bind to loopback only — the OAuth callback listener must not be
+    // reachable beyond localhost.
+    server.listen(port, 'localhost', () => {
       console.log(chalk.gray('Waiting for authentication...'))
-      open(authUrl.toString())
+      // open() rejects if no browser can be launched (e.g. headless host);
+      // fall back to printing the URL instead of an unhandled rejection.
+      open(authUrl.toString()).catch(() => {
+        console.log(chalk.yellow('Could not open a browser automatically. Open this URL to authorize:'))
+        console.log(chalk.cyan(authUrl.toString()))
+      })
     })
 
     server.on('error', (err) => {

--- a/test/lib/oauth.test.ts
+++ b/test/lib/oauth.test.ts
@@ -1,6 +1,6 @@
 import type { OAuthTokenResponse } from '../../src/lib/oauth'
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
-import { generatePKCE, generateSecureState, refreshAccessToken } from '../../src/lib/oauth'
+import { buildAuthorizeUrl, buildLoopbackRedirectUri, generatePKCE, generateSecureState, refreshAccessToken, resolveRedirectPort } from '../../src/lib/oauth'
 
 describe('oauth module', () => {
   beforeEach(() => {
@@ -303,6 +303,51 @@ describe('oauth module', () => {
           /OAuth requires ASANA_CLIENT_ID and ASANA_CLIENT_SECRET/,
         )
       })
+    })
+  })
+
+  describe('redirect configuration', () => {
+    afterEach(() => {
+      delete process.env.ASANA_OAUTH_REDIRECT_PORT
+    })
+
+    test('buildLoopbackRedirectUri builds a localhost callback URL', () => {
+      expect(buildLoopbackRedirectUri(8080)).toBe('http://localhost:8080/callback')
+      expect(buildLoopbackRedirectUri(7777)).toBe('http://localhost:7777/callback')
+    })
+
+    test('resolveRedirectPort prefers an explicit option over env and default', () => {
+      process.env.ASANA_OAUTH_REDIRECT_PORT = '9999'
+      expect(resolveRedirectPort(7000)).toBe(7000)
+    })
+
+    test('resolveRedirectPort falls back to env, then the 8080 default', () => {
+      process.env.ASANA_OAUTH_REDIRECT_PORT = '9100'
+      expect(resolveRedirectPort()).toBe(9100)
+      delete process.env.ASANA_OAUTH_REDIRECT_PORT
+      expect(resolveRedirectPort()).toBe(8080)
+    })
+
+    test('resolveRedirectPort ignores invalid values', () => {
+      process.env.ASANA_OAUTH_REDIRECT_PORT = 'not-a-port'
+      expect(resolveRedirectPort()).toBe(8080)
+      expect(resolveRedirectPort(0)).toBe(8080)
+      expect(resolveRedirectPort(-5)).toBe(8080)
+    })
+
+    test('buildAuthorizeUrl reflects the configured redirect_uri and uses PKCE S256', () => {
+      const url = new URL(buildAuthorizeUrl({
+        clientId: 'cid',
+        redirectUri: 'http://localhost:7777/callback',
+        scope: 'default',
+        state: 'st',
+        codeChallenge: 'cc',
+      }))
+      expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:7777/callback')
+      expect(url.searchParams.get('client_id')).toBe('cid')
+      expect(url.searchParams.get('scope')).toBe('default')
+      expect(url.searchParams.get('code_challenge')).toBe('cc')
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256')
     })
   })
 })

--- a/test/lib/oauth.test.ts
+++ b/test/lib/oauth.test.ts
@@ -333,6 +333,7 @@ describe('oauth module', () => {
       expect(resolveRedirectPort()).toBe(8080)
       expect(resolveRedirectPort(0)).toBe(8080)
       expect(resolveRedirectPort(-5)).toBe(8080)
+      expect(resolveRedirectPort(999999)).toBe(8080)
     })
 
     test('buildAuthorizeUrl reflects the configured redirect_uri and uses PKCE S256', () => {


### PR DESCRIPTION
## Summary

The browser OAuth flow hardcoded `http://localhost:8080/callback`, so a port conflict had no escape hatch, and Asana **command-line app** types (which only accept the OOB redirect) failed with `invalid_request: redirect_uri does not match` and no guidance. The OOB flow (`--no-browser`) already worked but was undiscoverable.

Decision: **keep the browser flow** (better UX for web/server apps) — the gaps were configurability and documentation.

## Changes
- Configurable loopback redirect port via `--redirect-port <port>` and `ASANA_OAUTH_REDIRECT_PORT` (default 8080), threaded consistently through the authorize URL, callback server, and token exchange.
- Extract pure, unit-tested helpers: `resolveRedirectPort`, `buildLoopbackRedirectUri`, `buildAuthorizeUrl`.
- Proactive hint (browser-flow startup) + reactive hint (on `redirect_uri`/`invalid_request` errors) to use `--no-browser` for command-line apps.
- Document the app-type → flow mapping in `README.md` and `skills/asana-cli/references/commands.md`.

## Verification
- `bun test test/` → 362 pass (5 new redirect-config tests).
- Smoke (isolated HOME): OOB → `redirect_uri=urn:ietf:wg:oauth:2.0:oob`; default → `localhost:8080/callback`; `--redirect-port 7777` → `localhost:7777/callback`.

Fixes #45

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable OAuth loopback redirect port with strict validation and safer localhost handling. Improves guidance for browser vs OOB flows and sanitizes error logs; fixes redirect_uri mismatches for Asana command-line apps.

- **New Features**
  - `--redirect-port <port>` and `ASANA_OAUTH_REDIRECT_PORT` (1–65535); helpers `resolveRedirectPort`, `buildLoopbackRedirectUri`, `buildAuthorizeUrl` with tests.
  - If a browser can’t open, print the auth URL; show a `--no-browser` hint at flow start; docs updated with app-type guidance.

- **Bug Fixes**
  - Clear `redirect_uri does not match` messaging with `--no-browser` guidance; sanitize error output by stripping line breaks; fail fast on bad port values.
  - Callback server binds to `localhost`; clearer port-conflict errors with a `--redirect-port` tip.

<sup>Written for commit f69a12b926d47c91d4da99934a11d824e9316681. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--redirect-port` to configure the OAuth loopback callback port, with fallback to `ASANA_OAUTH_REDIRECT_PORT`; browser-based OAuth now uses the selected port for the redirect and token exchange.
* **Bug Fixes**
  * Improved OAuth error reporting with sanitized stderr output, and added a clearer hint when redirect-URI mismatches occur (suggesting `--no-browser`).
* **Documentation**
  * Expanded “Using OAuth 2.0” to cover two login flows, required environment variables, redirect URL/port registration, and troubleshooting for `redirect_uri does not match`.
* **Tests**
  * Added/extended tests for redirect-port precedence/validation and for loopback redirect URL + authorize URL (PKCE S256) generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->