### PR TITLE
docs: add SonarCloud badge and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,32 +3,32 @@
 version: 2
 updates:
   # Bun dependencies (package.json / bun.lock)
-  - package-ecosystem: "bun"
-    directory: "/"
+  - package-ecosystem: bun
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: chore
+      include: scope
     groups:
       # Group non-major dev/runtime dependency bumps into a single PR
       minor-and-patch:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
 
   # GitHub Actions used in .github/workflows
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "ci"
-      include: "scope"
+      prefix: ci
+      include: scope
     groups:
       actions:
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-reference
+version: 2
+updates:
+  # Bun dependencies (package.json / bun.lock)
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # Group non-major dev/runtime dependency bumps into a single PR
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,21 @@ updates:
           - minor
           - patch
 
+  # Bun dependencies for the docs sub-package (docs/package.json / docs/bun.lock)
+  - package-ecosystem: bun
+    directory: /docs
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
   # GitHub Actions used in .github/workflows
   - package-ecosystem: github-actions
     directory: /

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/pleaseai/asana/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/asana/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pleaseai/asana/branch/main/graph/badge.svg)](https://codecov.io/gh/pleaseai/asana)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_asana&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_asana)
 
 명령줄에서 Asana 작업을 효율적으로 관리하세요.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/pleaseai/asana/actions/workflows/ci.yml/badge.svg)](https://github.com/pleaseai/asana/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/pleaseai/asana/branch/main/graph/badge.svg)](https://codecov.io/gh/pleaseai/asana)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pleaseai_asana&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pleaseai_asana)
 
 Manage your Asana tasks efficiently from the command line.
 


### PR DESCRIPTION
## Summary

- Add SonarCloud quality gate badge to `README.md` and `README.ko.md`
- Add `.github/dependabot.yml` with weekly updates for the `bun` and `github-actions` ecosystems

## Notes

- Socket badge was dropped: `@pleaseai/asana` is not published to npm/Socket, so its URLs 404 and fail the `markdown-link-check` hook. Can be re-added once published.
- SonarCloud badge assumes project key `pleaseai_asana` (`<org>_<repo>` default). Adjust `project=` if the registered key differs; the badge only renders once the project is set up on SonarCloud.
- Dependabot groups minor/patch bumps into a single PR per ecosystem; major updates open individually. Commit prefixes (`chore`/`ci`) follow the repo's conventional-commit rules.

## Test plan

- [x] `markdown-link-check` pre-commit hook passes
- [ ] Dependabot picks up config after merge (verified in repo Settings → Dependabot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a SonarCloud quality gate badge to both READMEs and set up Dependabot to keep `bun` and `github-actions` up to date weekly, including the `/docs` package.

- **New Features**
  - Added SonarCloud Quality Gate badge to `README.md` and `README.ko.md` (project key `pleaseai_asana`).

- **Dependencies**
  - Added `.github/dependabot.yml` for weekly `bun` updates at `/` and `/docs`, grouping minor/patch bumps (limit 10; commit prefix `chore`).
  - Enabled weekly `github-actions` updates with grouped minor/patch bumps (commit prefix `ci`); YAML uses plain scalars to satisfy repo ESLint rules.

<sup>Written for commit 2424cab96392ee5b47d57314fec68ed8b6ae4eee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated dependency and GitHub Actions update checks on a weekly schedule, with grouped minor/patch updates and a cap on the number of open update requests.
* **Documentation**
  * Added a SonarCloud “Quality Gate Status” badge to the main README.
  * Added the same quality badge to the Korean README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->