### PR TITLE
feat(hooks): redirect Asana URL WebFetch to the asana CLI

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebFetch|Fetch",
+        "hooks": [
+          { "type": "command", "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/intercept-webfetch.ts" }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/intercept-webfetch.ts
+++ b/hooks/intercept-webfetch.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env bun
+/**
+ * PreToolUse Hook: Intercept WebFetch/Fetch for Asana URLs
+ *
+ * Fetching an app.asana.com URL returns a JS-rendered shell, not the task data —
+ * and it bypasses authentication. This hook detects Asana URLs in WebFetch/Fetch
+ * calls and redirects the agent to the local `asana` CLI, which speaks the API
+ * directly and emits agent-friendly `toon` output.
+ *
+ * Adapted from chatbot-pf/engineering-standards (MCP variant) for this repo:
+ * the `asana` CLI itself is the redirect target instead of Asana MCP.
+ *
+ * URL forms:
+ *   V0 (legacy): https://app.asana.com/0/{project_id}/{task_id}
+ *   V1 (new):    https://app.asana.com/1/{workspace_id}/project/{project_id}/task/{task_id}
+ *                https://app.asana.com/1/{workspace_id}/task/{task_id}
+ *                .../task/{task_id}/comment/{comment_id}
+ */
+
+import process from 'node:process'
+
+// Minimal local shapes — avoids depending on @anthropic-ai/claude-agent-sdk.
+interface PreToolUseHookInput {
+  tool_name: string
+  tool_input: unknown
+}
+
+interface HookJSONOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'PreToolUse'
+    permissionDecision?: 'allow' | 'deny' | 'ask'
+    permissionDecisionReason?: string
+  }
+  systemMessage?: string
+}
+
+interface WebFetchToolInput {
+  url?: string
+  prompt?: string
+}
+
+interface AsanaUrlMatch {
+  type: 'task' | 'project' | 'comment' | 'unknown'
+  workspaceId?: string
+  projectId?: string
+  taskId?: string
+  commentId?: string
+}
+
+/**
+ * Parse an Asana URL and extract its identifiers, or return null if it is not
+ * a recognizable task/project/comment URL.
+ */
+export function parseAsanaUrl(url: string): AsanaUrlMatch | null {
+  // V1: Task with comment - /task/{task_id}/comment/{comment_id}
+  const v1CommentMatch = url.match(/app\.asana\.com\/1\/(\d+)\/(?:project\/(\d+)\/)?task\/(\d+)\/comment\/(\d+)/)
+  if (v1CommentMatch) {
+    const [, workspaceId, projectId, taskId, commentId] = v1CommentMatch
+    return { type: 'comment', workspaceId, projectId, taskId, commentId }
+  }
+
+  // V1: Task in project - /1/{workspace_id}/project/{project_id}/task/{task_id}
+  const v1TaskInProjectMatch = url.match(/app\.asana\.com\/1\/(\d+)\/project\/(\d+)\/task\/(\d+)/)
+  if (v1TaskInProjectMatch) {
+    const [, workspaceId, projectId, taskId] = v1TaskInProjectMatch
+    return { type: 'task', workspaceId, projectId, taskId }
+  }
+
+  // V1: Task without project - /1/{workspace_id}/task/{task_id}
+  const v1TaskMatch = url.match(/app\.asana\.com\/1\/(\d+)\/task\/(\d+)/)
+  if (v1TaskMatch) {
+    const [, workspaceId, taskId] = v1TaskMatch
+    return { type: 'task', workspaceId, taskId }
+  }
+
+  // V1: Project - /1/{workspace_id}/project/{project_id}
+  const v1ProjectMatch = url.match(/app\.asana\.com\/1\/(\d+)\/project\/(\d+)\/?(?:\?|$)/)
+  if (v1ProjectMatch) {
+    const [, workspaceId, projectId] = v1ProjectMatch
+    return { type: 'project', workspaceId, projectId }
+  }
+
+  // V0 (legacy): Task - /0/{project_id}/{task_id}
+  const v0TaskMatch = url.match(/app\.asana\.com\/0\/(\d+)\/(\d+)/)
+  if (v0TaskMatch) {
+    const [, projectId, taskId] = v0TaskMatch
+    return { type: 'task', projectId, taskId }
+  }
+
+  // V0 (legacy): Project - /0/{project_id}
+  const v0ProjectMatch = url.match(/app\.asana\.com\/0\/(\d+)\/?(?:\?|$)/)
+  if (v0ProjectMatch) {
+    const [, projectId] = v0ProjectMatch
+    return { type: 'project', projectId }
+  }
+
+  return null
+}
+
+/**
+ * Build the `asana` CLI guidance shown to the agent for a matched URL.
+ */
+export function buildCliGuidance(match: AsanaUrlMatch): string {
+  if (match.type === 'comment' && match.taskId) {
+    return `Asana comment detected. Use the asana CLI instead of WebFetch:
+
+  asana task comment list ${match.taskId} --format toon
+
+(The CLI lists a task's comments; there is no fetch-single-comment command.)`
+  }
+
+  if (match.type === 'task' && match.taskId) {
+    return `Asana task detected. Use the asana CLI instead of WebFetch:
+
+  asana task get ${match.taskId} --format toon`
+  }
+
+  if (match.type === 'project' && match.projectId) {
+    return `Asana project detected. Use the asana CLI instead of WebFetch:
+
+  asana project get ${match.projectId} --format toon`
+  }
+
+  return `Asana URL detected. Use the asana CLI instead of WebFetch:
+
+  asana --help          # list commands
+  asana task get <gid>  # a task
+  asana project get <gid>  # a project`
+}
+
+async function main(): Promise<void> {
+  try {
+    const input = await Bun.stdin.text()
+    const hookInput: PreToolUseHookInput = JSON.parse(input)
+
+    // Only act on fetch-style tools; pass everything else through untouched.
+    if (hookInput.tool_name !== 'WebFetch' && hookInput.tool_name !== 'Fetch') {
+      process.stdout.write(`${JSON.stringify({})}\n`)
+      process.exit(0)
+    }
+
+    const url = (hookInput.tool_input as WebFetchToolInput)?.url
+    const match = url ? parseAsanaUrl(url) : null
+
+    // Not an Asana URL → allow the fetch.
+    if (!match) {
+      process.stdout.write(`${JSON.stringify({})}\n`)
+      process.exit(0)
+    }
+
+    const output: HookJSONOutput = {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'Asana URL detected — use the asana CLI for authenticated, structured access',
+      },
+      systemMessage: `✓ ${buildCliGuidance(match)}`,
+    }
+
+    process.stdout.write(`${JSON.stringify(output)}\n`)
+    process.exit(0)
+  }
+  catch (error) {
+    // Never hard-fail the tool call: notify and fall back to WebFetch.
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    await Bun.write(Bun.stderr, `Hook error: ${errorMessage}\n`)
+    const output: HookJSONOutput = {
+      systemMessage: `⚠️ Asana hook error: ${errorMessage}. Falling back to WebFetch.`,
+    }
+    process.stdout.write(`${JSON.stringify(output)}\n`)
+    process.exit(0)
+  }
+}
+
+// Bun sets import.meta.main only for the directly-executed entry file, so tests
+// that import parseAsanaUrl/buildCliGuidance never trigger main().
+// main() handles its own errors and exits, so there is nothing to await here.
+if (import.meta.main) {
+  void main()
+}

--- a/hooks/intercept-webfetch.ts
+++ b/hooks/intercept-webfetch.ts
@@ -47,54 +47,111 @@ interface AsanaUrlMatch {
   commentId?: string
 }
 
+const ASANA_HOST = 'app.asana.com'
+
 /**
- * Parse an Asana URL and extract its identifiers, or return null if it is not
- * a recognizable task/project/comment URL.
+ * Match the Asana identifiers in a URL *pathname* (host already verified).
+ * Pathname excludes query/fragment, so anchored `^…$` patterns are exact.
  */
-export function parseAsanaUrl(url: string): AsanaUrlMatch | null {
-  // V1: Task with comment - /task/{task_id}/comment/{comment_id}
-  const v1CommentMatch = url.match(/app\.asana\.com\/1\/(\d+)\/(?:project\/(\d+)\/)?task\/(\d+)\/comment\/(\d+)/)
-  if (v1CommentMatch) {
-    const [, workspaceId, projectId, taskId, commentId] = v1CommentMatch
+function matchAsanaPath(path: string): AsanaUrlMatch | null {
+  // V1: Task with comment - /1/{workspace}/[project/{project}/]task/{task}/comment/{comment}
+  const v1Comment = /^\/1\/(\d+)\/(?:project\/(\d+)\/)?task\/(\d+)\/comment\/(\d+)/.exec(path)
+  if (v1Comment) {
+    const [, workspaceId, projectId, taskId, commentId] = v1Comment
     return { type: 'comment', workspaceId, projectId, taskId, commentId }
   }
 
-  // V1: Task in project - /1/{workspace_id}/project/{project_id}/task/{task_id}
-  const v1TaskInProjectMatch = url.match(/app\.asana\.com\/1\/(\d+)\/project\/(\d+)\/task\/(\d+)/)
-  if (v1TaskInProjectMatch) {
-    const [, workspaceId, projectId, taskId] = v1TaskInProjectMatch
+  // V1: Task in project - /1/{workspace}/project/{project}/task/{task}
+  const v1TaskInProject = /^\/1\/(\d+)\/project\/(\d+)\/task\/(\d+)/.exec(path)
+  if (v1TaskInProject) {
+    const [, workspaceId, projectId, taskId] = v1TaskInProject
     return { type: 'task', workspaceId, projectId, taskId }
   }
 
-  // V1: Task without project - /1/{workspace_id}/task/{task_id}
-  const v1TaskMatch = url.match(/app\.asana\.com\/1\/(\d+)\/task\/(\d+)/)
-  if (v1TaskMatch) {
-    const [, workspaceId, taskId] = v1TaskMatch
+  // V1: Task without project - /1/{workspace}/task/{task}
+  const v1Task = /^\/1\/(\d+)\/task\/(\d+)/.exec(path)
+  if (v1Task) {
+    const [, workspaceId, taskId] = v1Task
     return { type: 'task', workspaceId, taskId }
   }
 
-  // V1: Project - /1/{workspace_id}/project/{project_id}
-  const v1ProjectMatch = url.match(/app\.asana\.com\/1\/(\d+)\/project\/(\d+)\/?(?:\?|$)/)
-  if (v1ProjectMatch) {
-    const [, workspaceId, projectId] = v1ProjectMatch
+  // V1: Project - /1/{workspace}/project/{project}
+  const v1Project = /^\/1\/(\d+)\/project\/(\d+)\/?$/.exec(path)
+  if (v1Project) {
+    const [, workspaceId, projectId] = v1Project
     return { type: 'project', workspaceId, projectId }
   }
 
-  // V0 (legacy): Task - /0/{project_id}/{task_id}
-  const v0TaskMatch = url.match(/app\.asana\.com\/0\/(\d+)\/(\d+)/)
-  if (v0TaskMatch) {
-    const [, projectId, taskId] = v0TaskMatch
+  // V0 (legacy): Task - /0/{project}/{task}
+  const v0Task = /^\/0\/(\d+)\/(\d+)/.exec(path)
+  if (v0Task) {
+    const [, projectId, taskId] = v0Task
     return { type: 'task', projectId, taskId }
   }
 
-  // V0 (legacy): Project - /0/{project_id}
-  const v0ProjectMatch = url.match(/app\.asana\.com\/0\/(\d+)\/?(?:\?|$)/)
-  if (v0ProjectMatch) {
-    const [, projectId] = v0ProjectMatch
+  // V0 (legacy): Project - /0/{project}
+  const v0Project = /^\/0\/(\d+)\/?$/.exec(path)
+  if (v0Project) {
+    const [, projectId] = v0Project
     return { type: 'project', projectId }
   }
 
   return null
+}
+
+/**
+ * Parse an Asana URL and extract its identifiers, or return null if it is not
+ * a recognizable task/project/comment URL.
+ *
+ * Parses with the `URL` constructor and verifies `hostname === app.asana.com`
+ * before matching, so a non-Asana URL that merely *contains* the string
+ * `app.asana.com` (e.g. `https://app.asana.com.evil.com/0/1/2` or
+ * `https://proxy.example.com/?to=https://app.asana.com/0/1/2`) is not matched.
+ * A non-string or malformed URL throws in `new URL()` and is caught as null.
+ */
+export function parseAsanaUrl(url: string): AsanaUrlMatch | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  }
+  catch {
+    return null
+  }
+
+  if (parsed.hostname !== ASANA_HOST) {
+    return null
+  }
+
+  return matchAsanaPath(parsed.pathname)
+}
+
+/**
+ * Decide the hook output for a tool call: deny + CLI guidance for an Asana URL,
+ * or an empty object (allow / pass-through) for anything else. Pure and
+ * side-effect free so both the `WebFetch` and `Fetch` paths are unit-testable.
+ */
+export function decideForToolCall(hookInput: PreToolUseHookInput): HookJSONOutput {
+  // Only act on fetch-style tools; pass everything else through untouched.
+  if (hookInput.tool_name !== 'WebFetch' && hookInput.tool_name !== 'Fetch') {
+    return {}
+  }
+
+  const url = (hookInput.tool_input as WebFetchToolInput)?.url
+  const match = url ? parseAsanaUrl(url) : null
+
+  // Not an Asana URL → allow the fetch.
+  if (!match) {
+    return {}
+  }
+
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: 'Asana URL detected — use the asana CLI for authenticated, structured access',
+    },
+    systemMessage: `⚠️ ${buildCliGuidance(match)}`,
+  }
 }
 
 /**
@@ -132,31 +189,7 @@ async function main(): Promise<void> {
   try {
     const input = await Bun.stdin.text()
     const hookInput: PreToolUseHookInput = JSON.parse(input)
-
-    // Only act on fetch-style tools; pass everything else through untouched.
-    if (hookInput.tool_name !== 'WebFetch' && hookInput.tool_name !== 'Fetch') {
-      process.stdout.write(`${JSON.stringify({})}\n`)
-      process.exit(0)
-    }
-
-    const url = (hookInput.tool_input as WebFetchToolInput)?.url
-    const match = url ? parseAsanaUrl(url) : null
-
-    // Not an Asana URL → allow the fetch.
-    if (!match) {
-      process.stdout.write(`${JSON.stringify({})}\n`)
-      process.exit(0)
-    }
-
-    const output: HookJSONOutput = {
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: 'Asana URL detected — use the asana CLI for authenticated, structured access',
-      },
-      systemMessage: `✓ ${buildCliGuidance(match)}`,
-    }
-
+    const output = decideForToolCall(hookInput)
     process.stdout.write(`${JSON.stringify(output)}\n`)
     process.exit(0)
   }

--- a/test/hooks/intercept-webfetch.test.ts
+++ b/test/hooks/intercept-webfetch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { buildCliGuidance, parseAsanaUrl } from '../../hooks/intercept-webfetch'
+import { buildCliGuidance, decideForToolCall, parseAsanaUrl } from '../../hooks/intercept-webfetch'
 
 describe('parseAsanaUrl', () => {
   describe('V0 (legacy) format', () => {
@@ -116,5 +116,71 @@ describe('buildCliGuidance', () => {
   test('falls back to `asana --help` for an unknown shape', () => {
     const guidance = buildCliGuidance({ type: 'unknown' })
     expect(guidance).toContain('asana --help')
+  })
+})
+
+describe('parseAsanaUrl host boundary', () => {
+  test('rejects a look-alike host with app.asana.com as a prefix', () => {
+    expect(parseAsanaUrl('https://app.asana.com.evil.com/0/123/456')).toBeNull()
+  })
+
+  test('rejects app.asana.com appearing in the path of another host', () => {
+    expect(parseAsanaUrl('https://evil.com/app.asana.com/0/123/456')).toBeNull()
+  })
+
+  test('rejects app.asana.com embedded in a query string (proxy/redirect)', () => {
+    expect(parseAsanaUrl('https://proxy.example.com/fetch?target=https://app.asana.com/0/123/456')).toBeNull()
+  })
+
+  test('rejects a different asana subdomain', () => {
+    expect(parseAsanaUrl('https://myapp.asana.com/0/123/456')).toBeNull()
+  })
+
+  test('returns null for a non-URL string instead of throwing', () => {
+    expect(parseAsanaUrl('not a url')).toBeNull()
+  })
+
+  test('ignores a URL fragment after a project id', () => {
+    expect(parseAsanaUrl('https://app.asana.com/0/1206043162733419#section')).toEqual({
+      type: 'project',
+      projectId: '1206043162733419',
+    })
+  })
+})
+
+describe('decideForToolCall', () => {
+  const taskUrl = 'https://app.asana.com/1/15793206719/task/12058909747493732'
+
+  test('denies a WebFetch of an Asana task URL with CLI guidance', () => {
+    const out = decideForToolCall({ tool_name: 'WebFetch', tool_input: { url: taskUrl } })
+    expect(out.hookSpecificOutput?.permissionDecision).toBe('deny')
+    expect(out.systemMessage).toContain('asana task get 12058909747493732 --format toon')
+  })
+
+  test('denies the Fetch tool path the same way as WebFetch', () => {
+    const out = decideForToolCall({ tool_name: 'Fetch', tool_input: { url: taskUrl } })
+    expect(out.hookSpecificOutput?.permissionDecision).toBe('deny')
+    expect(out.systemMessage).toContain('asana task get 12058909747493732 --format toon')
+  })
+
+  test('does not prefix the deny message with a success checkmark', () => {
+    const out = decideForToolCall({ tool_name: 'WebFetch', tool_input: { url: taskUrl } })
+    expect(out.systemMessage?.startsWith('✓')).toBe(false)
+    expect(out.systemMessage?.startsWith('⚠️')).toBe(true)
+  })
+
+  test('allows (empty output) a non-Asana WebFetch', () => {
+    const out = decideForToolCall({ tool_name: 'WebFetch', tool_input: { url: 'https://github.com/owner/repo' } })
+    expect(out).toEqual({})
+  })
+
+  test('passes through a non-fetch tool', () => {
+    const out = decideForToolCall({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+    expect(out).toEqual({})
+  })
+
+  test('allows a fetch with no url field', () => {
+    const out = decideForToolCall({ tool_name: 'Fetch', tool_input: {} })
+    expect(out).toEqual({})
   })
 })

--- a/test/hooks/intercept-webfetch.test.ts
+++ b/test/hooks/intercept-webfetch.test.ts
@@ -148,6 +148,40 @@ describe('parseAsanaUrl host boundary', () => {
   })
 })
 
+// Task/comment routes are matched by prefix on purpose: Asana appends view/focus
+// segments to real task URLs (e.g. the `/f` focus suffix), and those must still
+// redirect to the task. Project routes stay exact-anchored, and the comment
+// route is ordered before task so it is never shadowed. Locking this so a future
+// "tighten to exact match" change can't silently drop real focus URLs.
+describe('parseAsanaUrl trailing view/focus segments (intentional leniency)', () => {
+  test('treats a V0 focus URL (/f suffix) as its task', () => {
+    expect(parseAsanaUrl('https://app.asana.com/0/1206043162733419/12058909747493732/f')).toEqual({
+      type: 'task',
+      projectId: '1206043162733419',
+      taskId: '12058909747493732',
+    })
+  })
+
+  test('treats a V1 focus URL (/f suffix) as its task', () => {
+    expect(parseAsanaUrl('https://app.asana.com/1/15793206719/project/1206043162733419/task/12058909747493732/f')).toEqual({
+      type: 'task',
+      workspaceId: '15793206719',
+      projectId: '1206043162733419',
+      taskId: '12058909747493732',
+    })
+  })
+
+  test('still prioritizes the comment route over task when both could match', () => {
+    expect(parseAsanaUrl('https://app.asana.com/1/15793206719/task/12058909747493732/comment/9876543210')).toEqual({
+      type: 'comment',
+      workspaceId: '15793206719',
+      projectId: undefined,
+      taskId: '12058909747493732',
+      commentId: '9876543210',
+    })
+  })
+})
+
 describe('decideForToolCall', () => {
   const taskUrl = 'https://app.asana.com/1/15793206719/task/12058909747493732'
 

--- a/test/hooks/intercept-webfetch.test.ts
+++ b/test/hooks/intercept-webfetch.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+
+import { buildCliGuidance, parseAsanaUrl } from '../../hooks/intercept-webfetch'
+
+describe('parseAsanaUrl', () => {
+  describe('V0 (legacy) format', () => {
+    test('parses task URL', () => {
+      const url = 'https://app.asana.com/0/1206043162733419/12058909747493732'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'task',
+        projectId: '1206043162733419',
+        taskId: '12058909747493732',
+      })
+    })
+
+    test('parses project URL', () => {
+      const url = 'https://app.asana.com/0/1206043162733419'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'project',
+        projectId: '1206043162733419',
+      })
+    })
+
+    test('parses project URL with query params', () => {
+      const url = 'https://app.asana.com/0/1206043162733419?tab=overview'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'project',
+        projectId: '1206043162733419',
+      })
+    })
+  })
+
+  describe('V1 (new) format', () => {
+    test('parses task in project URL', () => {
+      const url = 'https://app.asana.com/1/15793206719/project/1206043162733419/task/12058909747493732'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'task',
+        workspaceId: '15793206719',
+        projectId: '1206043162733419',
+        taskId: '12058909747493732',
+      })
+    })
+
+    test('parses task without project URL', () => {
+      const url = 'https://app.asana.com/1/15793206719/task/12058909747493732'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'task',
+        workspaceId: '15793206719',
+        taskId: '12058909747493732',
+      })
+    })
+
+    test('parses project URL', () => {
+      const url = 'https://app.asana.com/1/15793206719/project/1206043162733419'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'project',
+        workspaceId: '15793206719',
+        projectId: '1206043162733419',
+      })
+    })
+
+    test('parses comment URL with project', () => {
+      const url = 'https://app.asana.com/1/15793206719/project/1206043162733419/task/12058909747493732/comment/9876543210'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'comment',
+        workspaceId: '15793206719',
+        projectId: '1206043162733419',
+        taskId: '12058909747493732',
+        commentId: '9876543210',
+      })
+    })
+
+    test('parses comment URL without project', () => {
+      const url = 'https://app.asana.com/1/15793206719/task/12058909747493732/comment/9876543210'
+      expect(parseAsanaUrl(url)).toEqual({
+        type: 'comment',
+        workspaceId: '15793206719',
+        projectId: undefined,
+        taskId: '12058909747493732',
+        commentId: '9876543210',
+      })
+    })
+  })
+
+  describe('invalid URLs', () => {
+    test('returns null for non-Asana URL', () => {
+      expect(parseAsanaUrl('https://github.com/owner/repo')).toBeNull()
+    })
+
+    test('returns null for Asana home URL', () => {
+      expect(parseAsanaUrl('https://app.asana.com/')).toBeNull()
+    })
+  })
+})
+
+describe('buildCliGuidance', () => {
+  test('routes a task to `asana task get`', () => {
+    const guidance = buildCliGuidance({ type: 'task', taskId: '12058909747493732' })
+    expect(guidance).toContain('asana task get 12058909747493732 --format toon')
+  })
+
+  test('routes a project to `asana project get`', () => {
+    const guidance = buildCliGuidance({ type: 'project', projectId: '1206043162733419' })
+    expect(guidance).toContain('asana project get 1206043162733419 --format toon')
+  })
+
+  test('routes a comment to `asana task comment list`', () => {
+    const guidance = buildCliGuidance({
+      type: 'comment',
+      taskId: '12058909747493732',
+      commentId: '9876543210',
+    })
+    expect(guidance).toContain('asana task comment list 12058909747493732 --format toon')
+  })
+
+  test('falls back to `asana --help` for an unknown shape', () => {
+    const guidance = buildCliGuidance({ type: 'unknown' })
+    expect(guidance).toContain('asana --help')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a `PreToolUse` hook that intercepts `WebFetch` and `Fetch` tool calls targeting `app.asana.com` URLs and redirects the agent to the local `asana` CLI instead of hitting the Asana web app.

The hook covers both URL forms used by the Asana web app:
- **V0**: `https://app.asana.com/0/<project>/<task>`
- **V1**: `https://app.asana.com/1/...`

When a match is detected, the hook blocks the fetch and returns a structured error that names the correct CLI commands:
- `asana task get <task-id>` — read a task
- `asana project get <project-id>` — read a project
- `asana task comment list <task-id> --format toon` — list comments

## Changes

- `hooks/intercept-webfetch.ts` — PreToolUse hook implementation
- `hooks/hooks.json` — hook registration (wires the hook into Claude Code's PreToolUse pipeline)
- `test/hooks/intercept-webfetch.test.ts` — bun:test suite (14 tests covering V0/V1 URL matching, non-Asana pass-through, and CLI hint formatting)

## Verification

- `bun test test/hooks/intercept-webfetch.test.ts` → 14 tests pass
- `bun run lint` → clean
- `bunx tsc --noEmit` → no new errors

## Notes

Adapted from the `chatbot-pf/engineering-standards` MCP-variant hook to target this repo's CLI. Tests were ported from the original vitest suite to bun:test.

**Intentionally excluded from this PR:**
- `.claude/settings.json` (a separate plugin-enablement change — nostics/axi — unrelated to this hook)
- `.idea/`, `.agents/`, `.claude/agent-memory/`, `.claude/skills/`, `.please/docs/review/`, `skills-lock.json` (local/untracked artifacts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `WebFetch`/`Fetch` calls to `app.asana.com` and redirects to the local `asana` CLI for authenticated, structured access. Supports V0 and V1 links (task, project, comment) and preserves Asana task focus URLs (`/f`) via intentional prefix matching.

- **New Features**
  - Added `PreToolUse` hook (`hooks/intercept-webfetch.ts`) and registration (`hooks/hooks.json`).
  - Denies Asana fetches with guidance for:
    - `asana task get <task-id> --format toon`
    - `asana project get <project-id> --format toon`
    - `asana task comment list <task-id> --format toon`
  - Non-Asana URLs pass through; on hook error, fetch proceeds with a warning.
  - Tests: cover V0/V1, host boundary, both tool paths, CLI guidance, and lenient task matching for `/f` focus URLs with comment-route precedence.

- **Bug Fixes**
  - Strict hostname check using `new URL()` to avoid look-alike/proxied domains.
  - Pathname matching with anchored `RegExp.exec()` for accuracy.
  - Extracted pure `decideForToolCall()` for unit tests; deny message uses a warning prefix.

<sup>Written for commit de95547184b92adc77092a4800a672c828452cfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-tool hook that intercepts web fetches targeting supported Asana links and instructs you to use the local CLI instead.
  * Recognizes both legacy and versioned Asana URL patterns (tasks, projects, and comments) and passes through non-Asana or unrecognized inputs without blocking.
* **Tests**
  * Expanded test coverage for Asana URL detection, generated CLI guidance, and tool-call permission decisions (including edge cases and allow/pass-through behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->