### PR TITLE
chore: enable nostics and axi plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,8 @@
   },
   "enabledPlugins": {
     "skill-optimizer@pleaseai": true,
-    "bun@pleaseai": true
+    "bun@pleaseai": true,
+    "nostics@pleaseai": true,
+    "axi@pleaseai": true
   }
 }


### PR DESCRIPTION
## Summary
Enable two plugins in the asana repo's Claude Code settings (`.claude/settings.json`):

- `nostics@pleaseai` — structured diagnostics library tooling
- `axi@pleaseai` — Agent eXperience Interface standards (the asana CLI's AXI-adoption work targets this)

## Scope
Single-file config change. Split out from #55 (WebFetch-intercept hook) to keep commits atomic.

## Diff
```
   "enabledPlugins": {
     "skill-optimizer@pleaseai": true,
-    "bun@pleaseai": true
+    "bun@pleaseai": true,
+    "nostics@pleaseai": true,
+    "axi@pleaseai": true
   }
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `nostics@pleaseai` and `axi@pleaseai` in `.claude/settings.json` to provide structured diagnostics and AXI-standard support for local coding tasks. Single-file config change updating `enabledPlugins`.

<sup>Written for commit da999fbd85e9c27e9a434fa5410577bb0dad82c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the set of enabled AI-assisted tools in the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->