### PR TITLE
feat(custom-field): expose structured custom-field values (people gid, enum/multi_enum options, date ISO) in task custom-field list

### DIFF
--- a/skills/asana-cli/references/commands.md
+++ b/skills/asana-cli/references/commands.md
@@ -142,6 +142,25 @@ Asana caps combined dependencies + dependents at 50.
 
 - `asana task custom-field set <task-gid> <field-gid> <value>` — value coerced to field type (text/number/enum name or gid)
 - `asana task custom-field list <task-gid>`
+  - Each field reports `gid`, `name`, `type`, and `value` (the display string). For
+    `people`-type fields the output also carries a `people` array of `{gid, name}` —
+    use those gids to @-mention someone in a comment (see below).
+
+### @-mention a person from a people field
+
+`task comment add --html` renders an Asana mention from `<a data-asana-gid="USER_GID"/>`.
+Read the user gid out of a people custom field, then post the comment (use `--format json`
+to parse reliably):
+
+```bash
+# 1. Read the reporter's gid from a people field
+asana task custom-field list 1207891234567890 --format json
+#    → custom_fields[].people[].gid for the people-type field
+
+# 2. Mention them in a comment
+asana task comment add 1207891234567890 \
+  '<a data-asana-gid="111"/> resolved — see PR #482' --html
+```
 
 ## task batch operations
 

--- a/skills/asana-cli/references/commands.md
+++ b/skills/asana-cli/references/commands.md
@@ -142,9 +142,13 @@ Asana caps combined dependencies + dependents at 50.
 
 - `asana task custom-field set <task-gid> <field-gid> <value>` — value coerced to field type (text/number/enum name or gid)
 - `asana task custom-field list <task-gid>`
-  - Each field reports `gid`, `name`, `type`, and `value` (the display string). For
-    `people`-type fields the output also carries a `people` array of `{gid, name}` —
-    use those gids to @-mention someone in a comment (see below).
+  - Each field reports `gid`, `name`, `type`, and `value` (the display string).
+    Types whose `value` hides machine-readable data also carry a structured key
+    (use `--format json` to read them):
+    - `people` → `people`: `[{gid, name}]` — user gids for @-mentions (see below)
+    - `enum` → `enum_option`: the selected `{gid, name}`, or `null` if unset
+    - `multi_enum` → `enum_options`: the selected `[{gid, name}]`
+    - `date` → `date`: the raw `{date, date_time}` ISO value, or `null` if unset
 
 ### @-mention a person from a people field
 

--- a/src/commands/custom-field.ts
+++ b/src/commands/custom-field.ts
@@ -3,13 +3,13 @@ import chalk from 'chalk'
 import { Command } from 'commander'
 import { getAsanaClient } from '../lib/asana-client'
 import { loadConfig } from '../lib/config'
-import { coerceCustomFieldValue } from '../lib/custom-fields'
+import { coerceCustomFieldValue, mapTaskCustomField } from '../lib/custom-fields'
 import { handleAsanaError } from '../lib/error-handler'
 import { validateGid, ValidationError } from '../lib/validators'
 import { formatOutput, getOutputFormat } from '../utils/formatter'
 
 const TASK_CUSTOM_FIELD_FIELDS = {
-  opt_fields: 'custom_fields.name,custom_fields.resource_subtype,custom_fields.display_value',
+  opt_fields: 'custom_fields.name,custom_fields.resource_subtype,custom_fields.display_value,custom_fields.people_value.gid,custom_fields.people_value.name',
 }
 const FIELD_DEFINITION_FIELDS = {
   opt_fields: 'name,resource_subtype,enum_options.name,enum_options.enabled',
@@ -74,12 +74,7 @@ export function createTaskCustomFieldCommand(): Command {
         validateGid(taskGid, 'Task GID')
         const client = getAsanaClient()
         const task = await client.tasks.findById(taskGid, TASK_CUSTOM_FIELD_FIELDS)
-        const fields = (task.custom_fields || []).map((field: any) => ({
-          gid: field.gid,
-          name: field.name,
-          type: field.resource_subtype ?? 'unknown',
-          value: field.display_value ?? '',
-        }))
+        const fields = (task.custom_fields || []).map(mapTaskCustomField)
 
         if (fields.length === 0) {
           console.log(chalk.yellow('No custom fields found'))

--- a/src/commands/custom-field.ts
+++ b/src/commands/custom-field.ts
@@ -9,7 +9,19 @@ import { validateGid, ValidationError } from '../lib/validators'
 import { formatOutput, getOutputFormat } from '../utils/formatter'
 
 const TASK_CUSTOM_FIELD_FIELDS = {
-  opt_fields: 'custom_fields.name,custom_fields.resource_subtype,custom_fields.display_value,custom_fields.people_value.gid,custom_fields.people_value.name',
+  opt_fields: [
+    'custom_fields.name',
+    'custom_fields.resource_subtype',
+    'custom_fields.display_value',
+    'custom_fields.people_value.gid',
+    'custom_fields.people_value.name',
+    'custom_fields.enum_value.gid',
+    'custom_fields.enum_value.name',
+    'custom_fields.multi_enum_values.gid',
+    'custom_fields.multi_enum_values.name',
+    'custom_fields.date_value.date',
+    'custom_fields.date_value.date_time',
+  ].join(','),
 }
 const FIELD_DEFINITION_FIELDS = {
   opt_fields: 'name,resource_subtype,enum_options.name,enum_options.enabled',

--- a/src/lib/custom-fields.ts
+++ b/src/lib/custom-fields.ts
@@ -21,6 +21,50 @@ export interface CustomFieldDefinition {
 
 export const SUPPORTED_CUSTOM_FIELD_TYPES = ['text', 'number', 'enum'] as const
 
+/** A single user referenced by a `people`-type custom field. */
+export interface CustomFieldUser {
+  gid: string
+  name?: string
+}
+
+/** Compact summary of a custom field value as read from a task. */
+export interface TaskCustomFieldSummary {
+  gid: string
+  name?: string
+  type: string
+  value: string
+  /** Present only for `people`-type fields: the assigned users with their gids. */
+  people?: CustomFieldUser[]
+}
+
+/**
+ * Map a raw Asana task custom field into the compact summary the CLI prints.
+ *
+ * For `people`-type fields the raw `people_value` array (compact user objects
+ * with `gid`/`name`) is surfaced as a `people` array, so JSON consumers can read
+ * the underlying user gids needed to build an @-mention. `value` keeps the
+ * documented `display_value` string for every type, so the shape stays
+ * backward compatible.
+ */
+export function mapTaskCustomField(field: any): TaskCustomFieldSummary {
+  const type = field.resource_subtype ?? 'unknown'
+  const summary: TaskCustomFieldSummary = {
+    gid: field.gid,
+    name: field.name,
+    type,
+    value: field.display_value ?? '',
+  }
+
+  if (type === 'people') {
+    summary.people = (field.people_value ?? []).map((user: any) => ({
+      gid: user.gid,
+      name: user.name,
+    }))
+  }
+
+  return summary
+}
+
 /**
  * Coerce a raw CLI string into the value the Asana API expects for the field.
  *

--- a/src/lib/custom-fields.ts
+++ b/src/lib/custom-fields.ts
@@ -27,6 +27,18 @@ export interface CustomFieldUser {
   name?: string
 }
 
+/** A single enum option selected on an `enum`/`multi_enum` field. */
+export interface CustomFieldOption {
+  gid: string
+  name?: string
+}
+
+/** The raw value of a `date`-type field (ISO date, optional ISO date-time). */
+export interface CustomFieldDate {
+  date?: string
+  date_time?: string | null
+}
+
 /** Compact summary of a custom field value as read from a task. */
 export interface TaskCustomFieldSummary {
   gid: string
@@ -35,16 +47,30 @@ export interface TaskCustomFieldSummary {
   value: string
   /** Present only for `people`-type fields: the assigned users with their gids. */
   people?: CustomFieldUser[]
+  /** Present only for `enum`-type fields: the selected option, or `null` if unset. */
+  enum_option?: CustomFieldOption | null
+  /** Present only for `multi_enum`-type fields: the selected options. */
+  enum_options?: CustomFieldOption[]
+  /** Present only for `date`-type fields: the raw ISO value, or `null` if unset. */
+  date?: CustomFieldDate | null
+}
+
+function toOption(option: any): CustomFieldOption {
+  return { gid: option.gid, name: option.name }
 }
 
 /**
  * Map a raw Asana task custom field into the compact summary the CLI prints.
  *
- * For `people`-type fields the raw `people_value` array (compact user objects
- * with `gid`/`name`) is surfaced as a `people` array, so JSON consumers can read
- * the underlying user gids needed to build an @-mention. `value` keeps the
- * documented `display_value` string for every type, so the shape stays
- * backward compatible.
+ * `value` keeps the documented `display_value` string for every type, so the
+ * shape stays backward compatible. For types whose `display_value` hides
+ * machine-readable data, the structured value is surfaced as an extra key so
+ * JSON consumers can read it:
+ *
+ * - `people` → `people`: assigned users with their `gid`s (needed for @-mentions)
+ * - `enum` → `enum_option`: the selected option `{gid, name}`, or `null`
+ * - `multi_enum` → `enum_options`: the selected options `[{gid, name}]`
+ * - `date` → `date`: the raw `{date, date_time}` ISO value, or `null`
  */
 export function mapTaskCustomField(field: any): TaskCustomFieldSummary {
   const type = field.resource_subtype ?? 'unknown'
@@ -55,11 +81,27 @@ export function mapTaskCustomField(field: any): TaskCustomFieldSummary {
     value: field.display_value ?? '',
   }
 
-  if (type === 'people') {
-    summary.people = (field.people_value ?? []).map((user: any) => ({
-      gid: user.gid,
-      name: user.name,
-    }))
+  switch (type) {
+    case 'people':
+      summary.people = (field.people_value ?? []).map((user: any) => ({
+        gid: user.gid,
+        name: user.name,
+      }))
+      break
+
+    case 'enum':
+      summary.enum_option = field.enum_value ? toOption(field.enum_value) : null
+      break
+
+    case 'multi_enum':
+      summary.enum_options = (field.multi_enum_values ?? []).map(toOption)
+      break
+
+    case 'date':
+      summary.date = field.date_value
+        ? { date: field.date_value.date, date_time: field.date_value.date_time ?? null }
+        : null
+      break
   }
 
   return summary

--- a/src/lib/custom-fields.ts
+++ b/src/lib/custom-fields.ts
@@ -73,7 +73,9 @@ function toOption(option: any): CustomFieldOption {
  * - `date` → `date`: the raw `{date, date_time}` ISO value, or `null`
  */
 export function mapTaskCustomField(field: any): TaskCustomFieldSummary {
-  const type = field.resource_subtype ?? 'unknown'
+  // Mirror `coerceCustomFieldValue`: prefer `resource_subtype`, fall back to the
+  // legacy `type` property so legacy-shaped inputs still map to the right type.
+  const type = field.resource_subtype ?? field.type ?? 'unknown'
   const summary: TaskCustomFieldSummary = {
     gid: field.gid,
     name: field.name,

--- a/test/lib/custom-fields.test.ts
+++ b/test/lib/custom-fields.test.ts
@@ -152,4 +152,123 @@ describe('mapTaskCustomField', () => {
     expect(mapped.people).toEqual([])
     expect(mapped.value).toBe('')
   })
+
+  test('exposes the selected option gid for enum fields', () => {
+    const field = {
+      gid: '300',
+      name: 'Priority',
+      resource_subtype: 'enum',
+      display_value: 'High',
+      enum_value: { gid: '301', name: 'High', color: 'red', enabled: true },
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '300',
+      name: 'Priority',
+      type: 'enum',
+      value: 'High',
+      enum_option: { gid: '301', name: 'High' },
+    })
+  })
+
+  test('returns a null enum_option for an unset enum field', () => {
+    const mapped = mapTaskCustomField({
+      gid: '301',
+      name: 'Priority',
+      resource_subtype: 'enum',
+      display_value: '',
+    })
+
+    expect(mapped.enum_option).toBeNull()
+  })
+
+  test('exposes selected option gids for multi_enum fields', () => {
+    const field = {
+      gid: '400',
+      name: 'Teams',
+      resource_subtype: 'multi_enum',
+      display_value: 'Backend, Frontend',
+      multi_enum_values: [
+        { gid: '401', name: 'Backend', enabled: true },
+        { gid: '402', name: 'Frontend', enabled: true },
+      ],
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '400',
+      name: 'Teams',
+      type: 'multi_enum',
+      value: 'Backend, Frontend',
+      enum_options: [
+        { gid: '401', name: 'Backend' },
+        { gid: '402', name: 'Frontend' },
+      ],
+    })
+  })
+
+  test('returns an empty enum_options array for an unset multi_enum field', () => {
+    const mapped = mapTaskCustomField({
+      gid: '401',
+      name: 'Teams',
+      resource_subtype: 'multi_enum',
+      display_value: '',
+    })
+
+    expect(mapped.enum_options).toEqual([])
+  })
+
+  test('exposes the raw ISO date for date fields', () => {
+    const field = {
+      gid: '500',
+      name: 'Launch',
+      resource_subtype: 'date',
+      display_value: 'July 1, 2026',
+      date_value: { date: '2026-07-01', date_time: null },
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '500',
+      name: 'Launch',
+      type: 'date',
+      value: 'July 1, 2026',
+      date: { date: '2026-07-01', date_time: null },
+    })
+  })
+
+  test('preserves the date_time component when present', () => {
+    const mapped = mapTaskCustomField({
+      gid: '501',
+      name: 'Launch',
+      resource_subtype: 'date',
+      display_value: 'July 1, 2026 09:00',
+      date_value: { date: '2026-07-01', date_time: '2026-07-01T09:00:00.000Z' },
+    })
+
+    expect(mapped.date).toEqual({ date: '2026-07-01', date_time: '2026-07-01T09:00:00.000Z' })
+  })
+
+  test('returns a null date for an unset date field', () => {
+    const mapped = mapTaskCustomField({
+      gid: '502',
+      name: 'Launch',
+      resource_subtype: 'date',
+      display_value: '',
+    })
+
+    expect(mapped.date).toBeNull()
+  })
+
+  test('does not add typed keys from other types onto a text field', () => {
+    const mapped = mapTaskCustomField({
+      gid: '600',
+      name: 'Notes',
+      resource_subtype: 'text',
+      display_value: 'hi',
+    })
+
+    expect(mapped).not.toHaveProperty('people')
+    expect(mapped).not.toHaveProperty('enum_option')
+    expect(mapped).not.toHaveProperty('enum_options')
+    expect(mapped).not.toHaveProperty('date')
+  })
 })

--- a/test/lib/custom-fields.test.ts
+++ b/test/lib/custom-fields.test.ts
@@ -258,6 +258,24 @@ describe('mapTaskCustomField', () => {
     expect(mapped.date).toBeNull()
   })
 
+  test('falls back to the legacy `type` property when resource_subtype is absent', () => {
+    const field = {
+      gid: '700',
+      name: 'Reporter',
+      type: 'people',
+      display_value: 'Minsu Lee',
+      people_value: [{ gid: '111', name: 'Minsu Lee' }],
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '700',
+      name: 'Reporter',
+      type: 'people',
+      value: 'Minsu Lee',
+      people: [{ gid: '111', name: 'Minsu Lee' }],
+    })
+  })
+
   test('does not add typed keys from other types onto a text field', () => {
     const mapped = mapTaskCustomField({
       gid: '600',

--- a/test/lib/custom-fields.test.ts
+++ b/test/lib/custom-fields.test.ts
@@ -1,6 +1,6 @@
 import type { CustomFieldDefinition } from '../../src/lib/custom-fields'
 import { describe, expect, test } from 'bun:test'
-import { coerceCustomFieldValue } from '../../src/lib/custom-fields'
+import { coerceCustomFieldValue, mapTaskCustomField } from '../../src/lib/custom-fields'
 import { ValidationError } from '../../src/lib/validators'
 
 const TEXT_FIELD: CustomFieldDefinition = {
@@ -77,5 +77,79 @@ describe('coerceCustomFieldValue', () => {
 
       expect(coerceCustomFieldValue(field, 'legacy')).toBe('legacy')
     })
+  })
+})
+
+describe('mapTaskCustomField', () => {
+  test('maps a text field to gid/name/type/value', () => {
+    const field = {
+      gid: '100',
+      name: 'Description',
+      resource_subtype: 'text',
+      display_value: 'hello',
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '100',
+      name: 'Description',
+      type: 'text',
+      value: 'hello',
+    })
+  })
+
+  test('defaults missing type to unknown and missing display value to empty string', () => {
+    expect(mapTaskCustomField({ gid: '101', name: 'Mystery' })).toEqual({
+      gid: '101',
+      name: 'Mystery',
+      type: 'unknown',
+      value: '',
+    })
+  })
+
+  test('does not add a people array for non-people fields', () => {
+    const mapped = mapTaskCustomField({
+      gid: '102',
+      name: 'Priority',
+      resource_subtype: 'enum',
+      display_value: 'High',
+    })
+
+    expect(mapped).not.toHaveProperty('people')
+  })
+
+  test('exposes people_value gids for people fields alongside the display value', () => {
+    const field = {
+      gid: '200',
+      name: 'Reporter',
+      resource_subtype: 'people',
+      display_value: 'Minsu Lee, Jane Doe',
+      people_value: [
+        { gid: '111', name: 'Minsu Lee' },
+        { gid: '222', name: 'Jane Doe' },
+      ],
+    }
+
+    expect(mapTaskCustomField(field)).toEqual({
+      gid: '200',
+      name: 'Reporter',
+      type: 'people',
+      value: 'Minsu Lee, Jane Doe',
+      people: [
+        { gid: '111', name: 'Minsu Lee' },
+        { gid: '222', name: 'Jane Doe' },
+      ],
+    })
+  })
+
+  test('returns an empty people array for an unset people field', () => {
+    const mapped = mapTaskCustomField({
+      gid: '201',
+      name: 'Reporter',
+      resource_subtype: 'people',
+      display_value: '',
+    })
+
+    expect(mapped.people).toEqual([])
+    expect(mapped.value).toBe('')
   })
 })


### PR DESCRIPTION
## Summary

`task custom-field list` only exposed `display_value` (a display string) for every
custom field type, which hid machine-readable data callers need. The primary gap
(#74) was that **people** fields gave names but never the user **gid**, so callers
could not build a real Asana @-mention. While extending the read path, the same
`display_value`-only gap for `enum`/`multi_enum`/`date` fields is closed too.

## Changes

For each type whose `display_value` hides machine-readable data, a structured key
is added to the `list` output (and the matching `opt_fields` are requested):

| type | new key | shape |
|------|---------|-------|
| `people` | `people` | `[{ gid, name }]` — user gids for @-mentions |
| `enum` | `enum_option` | `{ gid, name }` or `null` if unset |
| `multi_enum` | `enum_options` | `[{ gid, name }]` |
| `date` | `date` | `{ date, date_time }` raw ISO, or `null` if unset |

- Routes every type through a unit-tested `mapTaskCustomField` helper.
- **Fully additive / backward compatible**: `gid`, `name`, `type`, `value`
  (= `display_value`) are unchanged for every type, and each structured key
  appears only for its own field type.
- Updated `skills/asana-cli/references/commands.md` documenting all structured
  keys plus a worked example combining the people gid with
  `task comment add --html` to @-mention a person.

## Test Plan

- [x] 13 `mapTaskCustomField` unit tests covering people / enum / multi_enum / date
      mapping, unset values (`null`/`[]`), and non-matching-type passthrough.
- [x] Full test suite: 449 pass / 0 fail.
- [x] ESLint clean.

## Related Issues

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom-field listings now provide richer, structured summaries, including people selections, single/multi-enum options, and date details.
  * Documentation added for mentioning a person from a people-type custom field using machine-readable JSON fields.

* **Bug Fixes**
  * Improved handling of missing or empty custom-field values with consistent defaults and correctly nullable structured outputs.

* **Documentation**
  * Expanded “task custom-field” reference with an end-to-end example for HTML mentions.

* **Tests**
  * Added/expanded unit coverage for mapping behavior across multiple custom-field types and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->