### PR TITLE
chore: declare pleaseai marketplace in claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,5 +23,13 @@
     "bun@pleaseai": true,
     "nostics@pleaseai": true,
     "axi@pleaseai": true
+  },
+  "extraKnownMarketplaces": {
+    "pleaseai": {
+      "source": {
+        "source": "github",
+        "repo": "pleaseai/claude-code-plugins"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds an `extraKnownMarketplaces` entry to `.claude/settings.json` declaring the `pleaseai` marketplace (`pleaseai/claude-code-plugins`).

The `enabledPlugins` list already references `pleaseai`-scoped plugins (`skill-optimizer@pleaseai`, `bun@pleaseai`, `nostics@pleaseai`, `axi@pleaseai`), but the marketplace that hosts them was not declared in this file. This makes those plugins resolvable from the settings alone.

## Changes

- `.claude/settings.json`: add `extraKnownMarketplaces.pleaseai` → `github:pleaseai/claude-code-plugins`

## Notes

- JSON validated with `python3 -m json.tool`.
- Configuration-only change; no code or behavior in the package is affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare the `pleaseai` marketplace in `.claude/settings.json` so `pleaseai`-scoped plugins resolve from settings. Adds `extraKnownMarketplaces.pleaseai` → `github:pleaseai/claude-code-plugins`, aligning with `enabledPlugins` (`skill-optimizer@pleaseai`, `bun@pleaseai`, `nostics@pleaseai`, `axi@pleaseai`).

<sup>Written for commit b53bc19cbb054ab472d759d8bc441fc15af3998b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional marketplace option, expanding the available plugin sources.
  * Saved configuration now includes the new marketplace entry for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->