### PR TITLE
feat(hooks): add SessionStart hook announcing the asana CLI and checking auth

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,12 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bun ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts" }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "WebFetch|Fetch",

--- a/hooks/session-start.ts
+++ b/hooks/session-start.ts
@@ -14,7 +14,7 @@
 
 import type { AsanaConfig } from '../src/types'
 import process from 'node:process'
-import { loadConfig } from '../src/lib/config'
+import { loadConfigStrict } from '../src/lib/config'
 
 // Minimal local shapes — avoids depending on @anthropic-ai/claude-agent-sdk.
 interface HookJSONOutput {
@@ -129,7 +129,10 @@ export function deriveAuthState(config: AsanaConfig | null, envToken: string | u
       hasToken: true,
       authType: config.authType,
       expiresAt: config.expiresAt,
-      hasRefreshToken: config.refreshToken != null,
+      // Match the CLI's truthiness check (`!config.refreshToken` in
+      // refreshTokenIfNeeded): an empty stored refresh token isn't usable, so
+      // it must not read as "auto-refresh will work".
+      hasRefreshToken: Boolean(config.refreshToken),
     }
   }
 
@@ -143,9 +146,12 @@ export function deriveAuthState(config: AsanaConfig | null, envToken: string | u
 /**
  * Read the stored credential into an {@link AsanaAuthState}. Impure (touches
  * config.json + process.env); kept thin so {@link deriveAuthState} stays testable.
+ * Uses the strict loader so a corrupt config throws here and is surfaced by
+ * main()'s catch as a hook-error systemMessage, rather than being silently
+ * collapsed to a misleading "not authenticated" warning.
  */
 export function readAuthState(): AsanaAuthState {
-  return deriveAuthState(loadConfig(), process.env.ASANA_ACCESS_TOKEN)
+  return deriveAuthState(loadConfigStrict(), process.env.ASANA_ACCESS_TOKEN)
 }
 
 async function main(): Promise<void> {

--- a/hooks/session-start.ts
+++ b/hooks/session-start.ts
@@ -42,17 +42,16 @@ export interface AsanaAuthState {
 const AUTH_LOGIN_HINT = 'Run `asana auth login` (OAuth) or set ASANA_ACCESS_TOKEN.'
 
 /**
- * Static, agent-facing primer on using the asana CLI this session. The auth
- * status line is appended by {@link decideSessionStart}.
+ * Static, agent-facing primer on using the asana CLI this session. Kept terse
+ * because it loads on every session (AXI §7: token-budget-aware) — just enough
+ * for the agent to orient and act. The auth status line is appended by
+ * {@link decideSessionStart}.
  */
 function buildAsanaGuidance(): string {
-  return `The \`asana\` CLI is available in this session. Prefer it for any Asana operation — tasks, projects, sections, comments, custom fields — over web requests or guessing.
-
-Common commands:
-  asana task list / task view <gid> / task create ...
-  asana project list / section list ...
-  asana fetch "<app.asana.com URL>" --format toon   # resolve any Asana link
-  asana auth whoami                                  # show current identity`
+  return `asana CLI available — prefer it for Asana ops (tasks, projects, comments, custom fields) over web requests.
+  asana task list | task view <gid> | task create
+  asana fetch "<app.asana.com URL>"   # resolve any Asana link
+  asana auth whoami                    # identity / default workspace`
 }
 
 /**

--- a/hooks/session-start.ts
+++ b/hooks/session-start.ts
@@ -12,8 +12,9 @@
  * Auth resolution is shared with the CLI via src/lib/config.ts.
  */
 
+import type { AsanaConfig } from '../src/types'
 import process from 'node:process'
-import { getAccessToken, loadConfig } from '../src/lib/config'
+import { loadConfig } from '../src/lib/config'
 
 // Minimal local shapes — avoids depending on @anthropic-ai/claude-agent-sdk.
 interface HookJSONOutput {
@@ -36,7 +37,7 @@ export interface AsanaAuthState {
   /** OAuth access-token expiry, epoch ms. */
   expiresAt?: number
   /** Whether an OAuth refresh token is stored (enables auto-refresh). */
-  hasRefreshToken?: boolean
+  hasRefreshToken: boolean
 }
 
 const AUTH_LOGIN_HINT = 'Run `asana auth login` (OAuth) or set ASANA_ACCESS_TOKEN.'
@@ -114,35 +115,61 @@ export function decideSessionStart(state: AsanaAuthState, now: number): HookJSON
 }
 
 /**
+ * Map a stored config + env token to the auth state, mirroring
+ * `getAccessToken`'s precedence (`config?.accessToken || ASANA_ACCESS_TOKEN`):
+ * a config token wins, the env var is the fallback. Crucially, OAuth metadata
+ * (authType/expiresAt/refreshToken) is read ONLY when the config token is the
+ * one that resolves — never paired with an env-resolved token, so a stale OAuth
+ * config can't trigger a false re-auth warning when ASANA_ACCESS_TOKEN is set.
+ * Pure, so the source-precedence logic is unit-testable.
+ */
+export function deriveAuthState(config: AsanaConfig | null, envToken: string | undefined): AsanaAuthState {
+  if (config?.accessToken) {
+    return {
+      hasToken: true,
+      authType: config.authType,
+      expiresAt: config.expiresAt,
+      hasRefreshToken: config.refreshToken != null,
+    }
+  }
+
+  if (envToken) {
+    return { hasToken: true, authType: 'pat', hasRefreshToken: false }
+  }
+
+  return { hasToken: false, hasRefreshToken: false }
+}
+
+/**
  * Read the stored credential into an {@link AsanaAuthState}. Impure (touches
- * config.json + process.env); kept thin so the decision logic stays testable.
+ * config.json + process.env); kept thin so {@link deriveAuthState} stays testable.
  */
 export function readAuthState(): AsanaAuthState {
-  const config = loadConfig()
-  const hasToken = getAccessToken(config) != null
-
-  return {
-    hasToken,
-    authType: config?.authType,
-    expiresAt: config?.expiresAt,
-    hasRefreshToken: config?.refreshToken != null,
-  }
+  return deriveAuthState(loadConfig(), process.env.ASANA_ACCESS_TOKEN)
 }
 
 async function main(): Promise<void> {
   try {
     // SessionStart input is consumed but not needed; drain stdin so the hook
-    // doesn't block on an unread pipe.
-    await Bun.stdin.text()
+    // doesn't block on an unread pipe. Skip when attached to an interactive TTY
+    // (manual runs / debugging) — there's no EOF coming, so the read would hang.
+    if (!process.stdin.isTTY) {
+      await Bun.stdin.text()
+    }
     const output = decideSessionStart(readAuthState(), Date.now())
     process.stdout.write(`${JSON.stringify(output)}\n`)
     process.exit(0)
   }
   catch (error) {
-    // Never hard-fail session startup: report and emit empty output.
+    // Never hard-fail session startup. Surface the failure via systemMessage
+    // (same contract as intercept-webfetch.ts) instead of a silent `{}`, so a
+    // config read/parse error is visible in-session rather than disappearing.
     const errorMessage = error instanceof Error ? error.message : String(error)
     await Bun.write(Bun.stderr, `Hook error: ${errorMessage}\n`)
-    process.stdout.write('{}\n')
+    const output: HookJSONOutput = {
+      systemMessage: `⚠️ Asana SessionStart hook error: ${errorMessage}. Session guidance was not injected.`,
+    }
+    process.stdout.write(`${JSON.stringify(output)}\n`)
     process.exit(0)
   }
 }

--- a/hooks/session-start.ts
+++ b/hooks/session-start.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env bun
+/**
+ * SessionStart Hook: announce the asana CLI and check auth at session start
+ *
+ * Two jobs, mirroring the project's "use the CLI, not raw web access" stance:
+ *   1. Inject agent-facing guidance so the session knows the `asana` CLI is the
+ *      preferred way to read/write Asana (analogous to intercept-webfetch.ts).
+ *   2. Inspect the stored credential (config.json / ASANA_ACCESS_TOKEN) and warn
+ *      the user when nothing usable is configured, so the first asana command
+ *      doesn't fail with a confusing auth error.
+ *
+ * Auth resolution is shared with the CLI via src/lib/config.ts.
+ */
+
+import process from 'node:process'
+import { getAccessToken, loadConfig } from '../src/lib/config'
+
+// Minimal local shapes — avoids depending on @anthropic-ai/claude-agent-sdk.
+interface HookJSONOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'SessionStart'
+    additionalContext?: string
+  }
+  systemMessage?: string
+}
+
+/**
+ * The credential picture the decision needs. Derived from config.json / env by
+ * {@link readAuthState}; passed explicitly so {@link decideSessionStart} stays
+ * pure and unit-testable.
+ */
+export interface AsanaAuthState {
+  /** Whether `getAccessToken()` resolved a non-empty token. */
+  hasToken: boolean
+  authType?: 'pat' | 'oauth'
+  /** OAuth access-token expiry, epoch ms. */
+  expiresAt?: number
+  /** Whether an OAuth refresh token is stored (enables auto-refresh). */
+  hasRefreshToken?: boolean
+}
+
+const AUTH_LOGIN_HINT = 'Run `asana auth login` (OAuth) or set ASANA_ACCESS_TOKEN.'
+
+/**
+ * Static, agent-facing primer on using the asana CLI this session. The auth
+ * status line is appended by {@link decideSessionStart}.
+ */
+function buildAsanaGuidance(): string {
+  return `The \`asana\` CLI is available in this session. Prefer it for any Asana operation — tasks, projects, sections, comments, custom fields — over web requests or guessing.
+
+Common commands:
+  asana task list / task view <gid> / task create ...
+  asana project list / section list ...
+  asana fetch "<app.asana.com URL>" --format toon   # resolve any Asana link
+  asana auth whoami                                  # show current identity`
+}
+
+/**
+ * Describe the credential for the agent. The OAuth-expired-but-refreshable case
+ * is informational (the CLI refreshes on the next command), not a failure.
+ */
+function buildAuthStatusLine(state: AsanaAuthState, now: number): string {
+  if (!state.hasToken) {
+    return `Auth: not authenticated. ${AUTH_LOGIN_HINT}`
+  }
+
+  if (state.authType === 'oauth') {
+    const expired = state.expiresAt != null && now >= state.expiresAt
+    if (expired && state.hasRefreshToken) {
+      return 'Auth: authenticated via OAuth (access token expired; the CLI will refresh it automatically on the next command).'
+    }
+    if (expired) {
+      return `Auth: OAuth session expired. ${AUTH_LOGIN_HINT}`
+    }
+    return 'Auth: authenticated via OAuth.'
+  }
+
+  return 'Auth: authenticated via personal access token.'
+}
+
+/**
+ * Whether the stored credential needs the user to act before asana commands
+ * work: no token at all, or an expired OAuth token with no refresh token.
+ */
+function needsReauth(state: AsanaAuthState, now: number): boolean {
+  if (!state.hasToken) {
+    return true
+  }
+  if (state.authType === 'oauth' && !state.hasRefreshToken) {
+    return state.expiresAt != null && now >= state.expiresAt
+  }
+  return false
+}
+
+/**
+ * Build the SessionStart output: always inject CLI guidance + auth status as
+ * additionalContext, and surface a user-visible warning only when the
+ * credential needs attention. Pure and side-effect free.
+ */
+export function decideSessionStart(state: AsanaAuthState, now: number): HookJSONOutput {
+  const additionalContext = `${buildAsanaGuidance()}\n\n${buildAuthStatusLine(state, now)}`
+
+  const output: HookJSONOutput = {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext,
+    },
+  }
+
+  if (needsReauth(state, now)) {
+    output.systemMessage = `⚠️ Asana CLI is not authenticated — ${AUTH_LOGIN_HINT}`
+  }
+
+  return output
+}
+
+/**
+ * Read the stored credential into an {@link AsanaAuthState}. Impure (touches
+ * config.json + process.env); kept thin so the decision logic stays testable.
+ */
+export function readAuthState(): AsanaAuthState {
+  const config = loadConfig()
+  const hasToken = getAccessToken(config) != null
+
+  return {
+    hasToken,
+    authType: config?.authType,
+    expiresAt: config?.expiresAt,
+    hasRefreshToken: config?.refreshToken != null,
+  }
+}
+
+async function main(): Promise<void> {
+  try {
+    // SessionStart input is consumed but not needed; drain stdin so the hook
+    // doesn't block on an unread pipe.
+    await Bun.stdin.text()
+    const output = decideSessionStart(readAuthState(), Date.now())
+    process.stdout.write(`${JSON.stringify(output)}\n`)
+    process.exit(0)
+  }
+  catch (error) {
+    // Never hard-fail session startup: report and emit empty output.
+    const errorMessage = error instanceof Error ? error.message : String(error)
+    await Bun.write(Bun.stderr, `Hook error: ${errorMessage}\n`)
+    process.stdout.write('{}\n')
+    process.exit(0)
+  }
+}
+
+// Bun sets import.meta.main only for the directly-executed entry file, so tests
+// that import decideSessionStart never trigger main().
+if (import.meta.main) {
+  void main()
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -32,6 +32,23 @@ export function loadConfig(): AsanaConfig | null {
   }
 }
 
+/**
+ * Load the config while distinguishing "no config" from "corrupt config".
+ * Returns null only when the file is absent; unlike {@link loadConfig}, it
+ * throws when the file exists but can't be read or parsed, so callers that need
+ * to surface a real configuration failure (e.g. the SessionStart hook) can tell
+ * a broken config apart from a logged-out state. {@link loadConfig} keeps its
+ * swallow-and-return-null contract for the CLI's degrade-gracefully paths.
+ */
+export function loadConfigStrict(): AsanaConfig | null {
+  if (!existsSync(CONFIG_FILE)) {
+    return null
+  }
+
+  const data = readFileSync(CONFIG_FILE, 'utf-8')
+  return JSON.parse(data) as AsanaConfig
+}
+
 export function getAccessToken(config: AsanaConfig | null = loadConfig()): string | null {
   return config?.accessToken || process.env.ASANA_ACCESS_TOKEN || null
 }

--- a/test/hooks/session-start.test.ts
+++ b/test/hooks/session-start.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from 'bun:test'
+
+import { decideSessionStart } from '../../hooks/session-start'
+
+// The auth state itself is derived from config.json / ASANA_ACCESS_TOKEN by the
+// impure `readAuthState`; here we only test the pure decision built on top of it.
+
+const NOW = 1_700_000_000_000
+
+describe('decideSessionStart', () => {
+  test('always injects asana CLI guidance as SessionStart additionalContext', () => {
+    const out = decideSessionStart({ hasToken: true, authType: 'pat' }, NOW)
+    expect(out.hookSpecificOutput?.hookEventName).toBe('SessionStart')
+    expect(out.hookSpecificOutput?.additionalContext).toContain('asana')
+    expect(out.hookSpecificOutput?.additionalContext).toContain('asana fetch')
+  })
+
+  describe('authenticated', () => {
+    test('reports a PAT identity and emits no user warning', () => {
+      const out = decideSessionStart({ hasToken: true, authType: 'pat' }, NOW)
+      expect(out.hookSpecificOutput?.additionalContext).toContain('personal access token')
+      expect(out.systemMessage).toBeUndefined()
+    })
+
+    test('reports a valid OAuth identity and emits no user warning', () => {
+      const out = decideSessionStart(
+        { hasToken: true, authType: 'oauth', expiresAt: NOW + 60_000, hasRefreshToken: true },
+        NOW,
+      )
+      expect(out.hookSpecificOutput?.additionalContext).toContain('OAuth')
+      expect(out.systemMessage).toBeUndefined()
+    })
+
+    test('notes auto-refresh for an expired OAuth token that still has a refresh token', () => {
+      const out = decideSessionStart(
+        { hasToken: true, authType: 'oauth', expiresAt: NOW - 1, hasRefreshToken: true },
+        NOW,
+      )
+      // The CLI refreshes on the next command, so this is informational, not a warning.
+      expect(out.hookSpecificOutput?.additionalContext).toContain('refresh')
+      expect(out.systemMessage).toBeUndefined()
+    })
+  })
+
+  describe('needs attention', () => {
+    test('warns the user when no token is configured', () => {
+      const out = decideSessionStart({ hasToken: false }, NOW)
+      expect(out.systemMessage).toContain('asana auth login')
+      expect(out.systemMessage?.startsWith('⚠️')).toBe(true)
+      expect(out.hookSpecificOutput?.additionalContext).toContain('asana auth login')
+    })
+
+    test('warns when an OAuth token is expired with no refresh token', () => {
+      const out = decideSessionStart(
+        { hasToken: true, authType: 'oauth', expiresAt: NOW - 1, hasRefreshToken: false },
+        NOW,
+      )
+      expect(out.systemMessage).toContain('asana auth login')
+      expect(out.systemMessage?.startsWith('⚠️')).toBe(true)
+    })
+  })
+})

--- a/test/hooks/session-start.test.ts
+++ b/test/hooks/session-start.test.ts
@@ -1,15 +1,16 @@
+import type { AsanaConfig } from '../../src/types'
 import { describe, expect, test } from 'bun:test'
 
-import { decideSessionStart } from '../../hooks/session-start'
+import { decideSessionStart, deriveAuthState } from '../../hooks/session-start'
 
-// The auth state itself is derived from config.json / ASANA_ACCESS_TOKEN by the
-// impure `readAuthState`; here we only test the pure decision built on top of it.
+// `deriveAuthState` maps config + env token to the auth state; `decideSessionStart`
+// is the pure decision built on top of it. Both are tested here.
 
 const NOW = 1_700_000_000_000
 
 describe('decideSessionStart', () => {
   test('always injects asana CLI guidance as SessionStart additionalContext', () => {
-    const out = decideSessionStart({ hasToken: true, authType: 'pat' }, NOW)
+    const out = decideSessionStart({ hasToken: true, authType: 'pat', hasRefreshToken: false }, NOW)
     expect(out.hookSpecificOutput?.hookEventName).toBe('SessionStart')
     expect(out.hookSpecificOutput?.additionalContext).toContain('asana')
     expect(out.hookSpecificOutput?.additionalContext).toContain('asana fetch')
@@ -17,7 +18,7 @@ describe('decideSessionStart', () => {
 
   describe('authenticated', () => {
     test('reports a PAT identity and emits no user warning', () => {
-      const out = decideSessionStart({ hasToken: true, authType: 'pat' }, NOW)
+      const out = decideSessionStart({ hasToken: true, authType: 'pat', hasRefreshToken: false }, NOW)
       expect(out.hookSpecificOutput?.additionalContext).toContain('personal access token')
       expect(out.systemMessage).toBeUndefined()
     })
@@ -44,7 +45,7 @@ describe('decideSessionStart', () => {
 
   describe('needs attention', () => {
     test('warns the user when no token is configured', () => {
-      const out = decideSessionStart({ hasToken: false }, NOW)
+      const out = decideSessionStart({ hasToken: false, hasRefreshToken: false }, NOW)
       expect(out.systemMessage).toContain('asana auth login')
       expect(out.systemMessage?.startsWith('⚠️')).toBe(true)
       expect(out.hookSpecificOutput?.additionalContext).toContain('asana auth login')
@@ -58,5 +59,50 @@ describe('decideSessionStart', () => {
       expect(out.systemMessage).toContain('asana auth login')
       expect(out.systemMessage?.startsWith('⚠️')).toBe(true)
     })
+  })
+})
+
+describe('deriveAuthState', () => {
+  const oauthConfig: AsanaConfig = {
+    accessToken: 'config-oauth-token',
+    authType: 'oauth',
+    expiresAt: NOW - 1,
+    // no refreshToken → an expired, non-refreshable OAuth session
+  }
+
+  test('uses config OAuth metadata when a config token resolves', () => {
+    const state = deriveAuthState(oauthConfig, undefined)
+    expect(state).toEqual({
+      hasToken: true,
+      authType: 'oauth',
+      expiresAt: NOW - 1,
+      hasRefreshToken: false,
+    })
+  })
+
+  test('a config token wins over ASANA_ACCESS_TOKEN, mirroring getAccessToken precedence', () => {
+    // getAccessToken is `config?.accessToken || env`, so the env var never
+    // overrides a present config token — the hook must report what the CLI uses.
+    const state = deriveAuthState(oauthConfig, 'env-pat-token')
+    expect(state.authType).toBe('oauth')
+    expect(state.expiresAt).toBe(NOW - 1)
+  })
+
+  test('falls back to the env PAT with no stale OAuth metadata when there is no config token', () => {
+    // Regression: an env token must never be paired with config OAuth fields,
+    // which would raise a false re-auth warning.
+    const state = deriveAuthState(null, 'env-pat-token')
+    expect(state).toEqual({ hasToken: true, authType: 'pat', hasRefreshToken: false })
+  })
+
+  test('treats an empty config token as absent and uses the env PAT', () => {
+    const stale: AsanaConfig = { accessToken: '', authType: 'oauth', expiresAt: NOW - 1 }
+    const state = deriveAuthState(stale, 'env-pat-token')
+    expect(state).toEqual({ hasToken: true, authType: 'pat', hasRefreshToken: false })
+  })
+
+  test('reports no token when neither config nor env provides one', () => {
+    const state = deriveAuthState(null, undefined)
+    expect(state).toEqual({ hasToken: false, hasRefreshToken: false })
   })
 })

--- a/test/hooks/session-start.test.ts
+++ b/test/hooks/session-start.test.ts
@@ -1,7 +1,12 @@
 import type { AsanaConfig } from '../../src/types'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 
 import { decideSessionStart, deriveAuthState } from '../../hooks/session-start'
+
+const HOOK_PATH = join(import.meta.dir, '../../hooks/session-start.ts')
 
 // `deriveAuthState` maps config + env token to the auth state; `decideSessionStart`
 // is the pure decision built on top of it. Both are tested here.
@@ -104,5 +109,47 @@ describe('deriveAuthState', () => {
   test('reports no token when neither config nor env provides one', () => {
     const state = deriveAuthState(null, undefined)
     expect(state).toEqual({ hasToken: false, hasRefreshToken: false })
+  })
+
+  test('treats an empty stored refresh token as no refresh token (CLI truthiness)', () => {
+    const config: AsanaConfig = {
+      accessToken: 'config-oauth-token',
+      authType: 'oauth',
+      expiresAt: NOW - 1,
+      refreshToken: '',
+    }
+    // Empty refresh token is unusable, so the CLI won't auto-refresh — the hook
+    // must reflect that rather than claiming auto-refresh will work.
+    expect(deriveAuthState(config, undefined).hasRefreshToken).toBe(false)
+  })
+})
+
+describe('main() error path (subprocess)', () => {
+  test('a corrupt config surfaces a hook-error systemMessage, not an auth warning', async () => {
+    const home = join(tmpdir(), `asana-hook-corrupt-${process.pid}`)
+    mkdirSync(join(home, '.asana-cli'), { recursive: true })
+    writeFileSync(join(home, '.asana-cli', 'config.json'), 'not valid json {')
+
+    try {
+      const proc = Bun.spawn(['bun', HOOK_PATH], {
+        // HOME points loadConfigStrict at the corrupt file; cwd avoids the repo
+        // .env; empty token keeps the credential path from masking the error.
+        env: { ...process.env, HOME: home, ASANA_ACCESS_TOKEN: '' },
+        cwd: tmpdir(),
+        stdin: 'ignore',
+        stdout: 'pipe',
+        stderr: 'ignore',
+      })
+
+      const parsed = JSON.parse(await new Response(proc.stdout).text())
+
+      expect(parsed.systemMessage).toContain('SessionStart hook error')
+      // A hard failure must not masquerade as a normal auth-state decision.
+      expect(parsed.systemMessage).not.toContain('not authenticated')
+      expect(parsed.hookSpecificOutput).toBeUndefined()
+    }
+    finally {
+      rmSync(home, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

Adds a **SessionStart hook** to the asana Claude Code plugin that runs at the start of every session. It does two things:

1. **Guidance injection** — emits `additionalContext` pointing the agent to prefer `asana` CLI commands for all Asana operations, consistent with the existing WebFetch-redirect hook.
2. **Auth check** — reads stored credentials (`~/.asana-cli/config.json` / `ASANA_ACCESS_TOKEN`) and, when no usable credential is found (no token, or expired OAuth token without a refresh token), surfaces a `⚠️ asana auth login` warning via `systemMessage`.

## Motivation

The existing `intercept-webfetch.ts` hook redirects mid-session WebFetch calls to the CLI, but there was no hook to set expectations at session start or to warn immediately when the user has no valid auth. This change closes both gaps.

## Changes

- `hooks/session-start.ts` (new) — SessionStart hook: pure `decideSessionStart(state, now)` decision function + thin `readAuthState()` I/O + `main()` stdin handler
- `test/hooks/session-start.test.ts` (new) — 6 unit tests covering authenticated, unauthenticated, expired-OAuth-no-refresh, and valid-OAuth cases
- `hooks/hooks.json` (modified) — registers the new `session-start.ts` entry alongside the existing `PreToolUse` hook

## Implementation Notes

- Mirrors the `hooks/intercept-webfetch.ts` pattern: pure decision function enables unit testing without I/O mocking
- Reuses `getAccessToken` / `loadConfig` from `src/lib/config.ts` (DRY — no duplication of auth logic)
- `hookSpecificOutput.additionalContext` carries the guidance; `systemMessage` carries the auth warning (only when needed)

## Quality Gates

- Full unit suite: **511 pass / 0 fail** (includes the 6 new tests)
- eslint clean on new files
- End-to-end hook execution verified for both authenticated and unauthenticated states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a SessionStart hook that announces the `asana` CLI and checks auth at session start. It injects short CLI guidance and warns to run `asana auth login` only when credentials are missing or OAuth is expired without a refresh token.

- **New Features**
  - Added `hooks/session-start.ts` to emit `additionalContext` with `asana` CLI guidance and an auth status line; warns via `systemMessage` only when reauth is needed.

- **Bug Fixes**
  - Hardened auth detection: resolve from `config` first, else `ASANA_ACCESS_TOKEN`; ignore stale OAuth metadata for env tokens; treat empty `refreshToken` as absent.
  - Improved robustness: use `loadConfigStrict()` to surface corrupt configs via `systemMessage`; skip stdin drain on interactive TTY to avoid blocking.

<sup>Written for commit d583631f6f0a0c80bd74660f8816b135ce0f497b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Session Start hook that displays Asana CLI usage guidance and shows current authentication status at the start of each session.
  * Evaluates PAT/OAuth validity and, when reauthentication is needed, includes an inline warning with the exact reauth command.
* **Bug Fixes**
  * Improved resilience: hook failures now surface as a session message (with a clear “SessionStart hook error”) without failing the session.
* **Tests**
  * Added automated coverage for PAT, valid/expired OAuth (with refresh), missing tokens, and corrupt-config error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->