### PR TITLE
feat(bench): agent-interface benchmark harness (CLI vs MCP vs code-mode)

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,126 @@
+# Asana agent-interface benchmark
+
+Measures cost, latency, and success rate when an agent performs the **same Asana
+tasks** with the **same model and prompts**, changing only the tool interface:
+
+| condition        | interface                                                                         | tool surface                             |
+| ---------------- | --------------------------------------------------------------------------------- | ---------------------------------------- |
+| `cli`            | this repo's `asana` CLI (AXI-style, TOON default output)                          | `Bash(asana:*)`                          |
+| `mcp`            | official Asana MCP (`mcp.asana.com/v2/mcp`) + tool search (deferred schemas)      | `mcp__asana`, `ENABLE_TOOL_SEARCH=auto`  |
+| `mcp-eager`\*    | same MCP with all schemas loaded upfront (tool search off)                        | `mcp__asana`, `ENABLE_TOOL_SEARCH=false` |
+| `executor`       | [executor.sh](https://executor.sh/docs/mcp-proxy) hosted MCP proxy (code-mode)    | `mcp__executor`                          |
+| `executor-cli`\* | the same proxy driven through its CLI (`executor tools search` / `executor call`) | `Bash(executor:*)`                       |
+
+`*` variant conditions, excluded from the default run — include them explicitly
+via `--conditions`.
+
+Methodology follows Kun Chen's [GitHub CLI vs MCP vs Tool Search vs Code Mode](https://kunchenguid.medium.com/i-benchmarked-github-cli-vs-mcp-vs-tool-search-vs-code-mode-turns-out-the-best-solution-is-none-93528d5039e4)
+benchmark, ported to Asana. Controlled variables:
+
+- **Identical prompts** — the only per-condition difference is a single
+  system-prompt sentence stating that the interface exists.
+- **Isolated runs** — every run gets a fresh empty temp cwd,
+  `--setting-sources project`, and `--strict-mcp-config`, so user hooks,
+  memory, global CLAUDE.md, and unrelated MCP servers cannot contaminate the
+  measurement.
+- **Separate ground truth** — fixture setup and verification call the Asana
+  REST API directly (`bench/src/asana.ts`), never the interface under test.
+- **State-based success** — verified against actual Asana state, not the
+  agent's claim of success.
+
+## Tasks
+
+| id             | shape                                                       | verification                      |
+| -------------- | ----------------------------------------------------------- | --------------------------------- |
+| `read_lookup`  | single read — find a task by name, report its due date      | seeded date appears in the answer |
+| `write_create` | single write — create a task with name, due date, notes     | field match via REST              |
+| `multi_step`   | chained — complete one of three tasks, add a comment        | completed flag + story exist      |
+| `aggregate`    | scan — count incomplete tasks by assignment, answer as JSON | JSON matches expected counts      |
+
+Each run seeds tasks under a unique prefix (`BM-xxxxx`) and deletes every
+prefixed task (including agent-created ones) on completion.
+
+## Prerequisites
+
+1. **asana CLI** — `brew install pleaseai/tap/asana-cli`, then
+   `asana auth login --token <PAT>`. The ground-truth client reuses the token
+   from `~/.asana-cli/config.json` (or `ASANA_ACCESS_TOKEN`).
+2. **Asana MCP OAuth** — authenticate interactively once so headless runs can
+   reuse the token: `claude mcp add --transport http asana https://mcp.asana.com/v2/mcp`,
+   then log in via `/mcp` inside a `claude` session.
+3. **executor** — `claude mcp add --transport http executor https://executor.sh/<your-org>/mcp`
+   (or `npx add-mcp`), then authenticate once via `/mcp`. Connect and
+   authenticate the Asana source in the executor.sh console beforehand.
+   Set the mutation policy to "always allow" — an approval gate pauses
+   headless runs (see caveats). Only the `executor-cli` variant needs the
+   local `executor` CLI installed.
+4. A logged-in `claude` CLI.
+
+## Running
+
+```bash
+# default: cli, mcp, executor × 4 tasks × 3 runs
+bun bench/src/run.ts
+
+# pick conditions/tasks/repetitions/model
+bun bench/src/run.ts --conditions cli,mcp,mcp-eager,executor \
+  --tasks read_lookup,aggregate --runs 5 --model claude-sonnet-5
+
+# reuse the project created by the first run; preview without spending
+bun bench/src/run.ts --project 12345 --dry-run
+```
+
+Options: `--workspace <gid>` (default: first workspace), `--project <gid>`
+(default: create a new bench project), `--max-turns` (40), `--timeout-min`
+(10), `--keep-tasks` (skip cleanup), `--session <tag>`.
+
+Per-run records land in `bench/results/<session>.jsonl`; a report prints when
+the run finishes. Regenerate reports any time:
+
+```bash
+bun bench/src/report.ts                       # all of results/
+bun bench/src/report.ts bench/results/x.jsonl # one session
+```
+
+## Metrics
+
+Extracted from the `claude -p --output-format stream-json` transcript:
+success rate (ground-truth verified), `total_cost_usd`,
+`duration_ms`/`duration_api_ms`, `num_turns`, tool-call counts by name, and
+token breakdown (input / output / cache read / cache creation). Reports show
+per-condition × per-task medians.
+
+## Example results (2026-07-06, sonnet, 48 runs)
+
+| condition   | success | cost (med) | time (med) | turns | tool calls |
+| ----------- | ------- | ---------- | ---------- | ----- | ---------- |
+| `mcp-eager` | 100%    | **$0.151** | **16.4s**  | **4** | 3          |
+| `cli`       | 100%    | $0.185     | 44.9s      | 11.5  | 10.5       |
+| `mcp`       | 100%    | $0.217     | 19.7s      | 5     | 4          |
+| `executor`  | 83%¹    | $0.416     | 52.2s      | 12.5  | 11.5       |
+
+¹ failures were executor's approval policy pausing mutations in a headless
+session (in one run the agent approved itself via `resume`).
+
+The CLI was cheapest-or-close on simple read/write tasks but degraded on the
+scan-style `aggregate` task ($0.350, 80.5s, 21 turns vs mcp-eager's $0.152,
+16.7s, 4 turns) because `task list` output lacks field expansion and
+aggregation — see [#88](https://github.com/pleaseai/asana/issues/88).
+
+## Known caveats
+
+- `ENABLE_TOOL_SEARCH` behavior can vary across Claude Code versions. If `mcp`
+  and `mcp-eager` results do not diverge, first verify the toggle applies on
+  your version.
+- Bash-based conditions (`cli`, `executor-cli`) include Claude Code's bash
+  command-inspection overhead. That is harness tax, but identical to real
+  usage, so it is measured as-is (same observation as Mario Zechner's
+  benchmark).
+- Runs execute sequentially, so time-of-day API latency drift can mix in.
+  Repetitions (`--runs`) sit on the outermost loop to spread it.
+- `aggregate` is judged by parsing the answer text; if the model ignores the
+  JSON format instruction the run counts as a failure even when the counts are
+  right.
+- executor's approval policies interact badly with headless sessions: the
+  agent either stalls asking for confirmation, or bypasses the gate itself by
+  calling `resume`. Set benchmark-scoped tools to "always allow".

--- a/bench/conditions/cli.json
+++ b/bench/conditions/cli.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/bench/conditions/executor.json
+++ b/bench/conditions/executor.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "executor": {
+      "type": "http",
+      "url": "https://executor.sh/minsu-lee-s-organization/mcp"
+    }
+  }
+}

--- a/bench/conditions/executor.json
+++ b/bench/conditions/executor.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "executor": {
       "type": "http",
-      "url": "https://executor.sh/minsu-lee-s-organization/mcp"
+      "url": "https://executor.sh/<your-org>/mcp"
     }
   }
 }

--- a/bench/conditions/mcp.json
+++ b/bench/conditions/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "asana": {
+      "type": "http",
+      "url": "https://mcp.asana.com/v2/mcp"
+    }
+  }
+}

--- a/bench/src/asana.ts
+++ b/bench/src/asana.ts
@@ -53,23 +53,32 @@ export class AsanaClient {
     path: string,
     body?: unknown,
     query?: Record<string, string>,
+    retries = 3,
   ): Promise<{ data: T, next_page?: { offset: string } | null }> {
     const url = new URL(API_BASE + path)
     for (const [key, value] of Object.entries(query ?? {})) {
       url.searchParams.set(key, value)
     }
-    const res = await fetch(url, {
-      method,
-      headers: {
-        'authorization': `Bearer ${this.token}`,
-        'content-type': 'application/json',
-      },
-      body: body === undefined ? undefined : JSON.stringify({ data: body }),
-    })
-    if (!res.ok) {
-      throw new Error(`Asana ${method} ${path} → ${res.status}: ${await res.text()}`)
+    for (let attempt = 0; ; attempt++) {
+      const res = await fetch(url, {
+        method,
+        headers: {
+          'authorization': `Bearer ${this.token}`,
+          'content-type': 'application/json',
+        },
+        body: body === undefined ? undefined : JSON.stringify({ data: body }),
+      })
+      if (res.status === 429 && attempt < retries) {
+        const retryAfterSeconds = Number(res.headers.get('retry-after')) || 2
+        console.warn(`Asana rate limit hit — retrying in ${retryAfterSeconds}s (${attempt + 1}/${retries})`)
+        await new Promise(resolve => setTimeout(resolve, retryAfterSeconds * 1000))
+        continue
+      }
+      if (!res.ok) {
+        throw new Error(`Asana ${method} ${path} → ${res.status}: ${await res.text()}`)
+      }
+      return await res.json() as { data: T, next_page?: { offset: string } | null }
     }
-    return await res.json() as { data: T, next_page?: { offset: string } | null }
   }
 
   me(): Promise<{ gid: string, name: string }> {

--- a/bench/src/asana.ts
+++ b/bench/src/asana.ts
@@ -4,7 +4,15 @@ import process from 'node:process'
 
 const API_BASE = 'https://app.asana.com/api/1.0'
 
-async function loadToken(): Promise<string> {
+let cachedToken: Promise<string> | undefined
+
+/** Memoized so repeated AsanaClient.create() calls (one per seed/verify) read the config file once. */
+function loadToken(): Promise<string> {
+  cachedToken ??= resolveToken()
+  return cachedToken
+}
+
+async function resolveToken(): Promise<string> {
   if (process.env.ASANA_ACCESS_TOKEN) {
     return process.env.ASANA_ACCESS_TOKEN
   }

--- a/bench/src/asana.ts
+++ b/bench/src/asana.ts
@@ -1,0 +1,110 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const API_BASE = 'https://app.asana.com/api/1.0'
+
+async function loadToken(): Promise<string> {
+  if (process.env.ASANA_ACCESS_TOKEN) {
+    return process.env.ASANA_ACCESS_TOKEN
+  }
+  const configFile = Bun.file(join(homedir(), '.asana-cli', 'config.json'))
+  if (await configFile.exists()) {
+    const config = await configFile.json()
+    if (config.accessToken) {
+      return config.accessToken
+    }
+  }
+  throw new Error('No Asana token found: set ASANA_ACCESS_TOKEN or run `asana auth login`')
+}
+
+/**
+ * Ground-truth client for fixture setup and verification.
+ * Talks to the Asana REST API directly so measurements of the interfaces
+ * under test (CLI / MCP / Executor) are never mixed with harness traffic.
+ */
+export class AsanaClient {
+  private constructor(private readonly token: string) {}
+
+  static async create(): Promise<AsanaClient> {
+    return new AsanaClient(await loadToken())
+  }
+
+  async request<T = any>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string>,
+  ): Promise<T> {
+    const url = new URL(API_BASE + path)
+    for (const [key, value] of Object.entries(query ?? {})) {
+      url.searchParams.set(key, value)
+    }
+    const res = await fetch(url, {
+      method,
+      headers: {
+        'authorization': `Bearer ${this.token}`,
+        'content-type': 'application/json',
+      },
+      body: body === undefined ? undefined : JSON.stringify({ data: body }),
+    })
+    if (!res.ok) {
+      throw new Error(`Asana ${method} ${path} → ${res.status}: ${await res.text()}`)
+    }
+    const payload = await res.json() as { data: T }
+    return payload.data
+  }
+
+  me(): Promise<{ gid: string, name: string }> {
+    return this.request('GET', '/users/me')
+  }
+
+  workspaces(): Promise<Array<{ gid: string, name: string }>> {
+    return this.request('GET', '/workspaces')
+  }
+
+  /** teams the authenticated user is a member of (project creation requires membership) */
+  myTeams(workspaceGid: string): Promise<Array<{ gid: string, name: string }>> {
+    return this.request('GET', '/users/me/teams', undefined, { organization: workspaceGid })
+  }
+
+  createProject(workspaceGid: string, name: string, teamGid?: string): Promise<{ gid: string, name: string }> {
+    return this.request('POST', '/projects', {
+      workspace: workspaceGid,
+      name,
+      ...(teamGid ? { team: teamGid } : {}),
+    })
+  }
+
+  getProject(gid: string): Promise<{ gid: string, name: string }> {
+    return this.request('GET', `/projects/${gid}`)
+  }
+
+  createTask(fields: Record<string, unknown>): Promise<{ gid: string, name: string }> {
+    return this.request('POST', '/tasks', fields)
+  }
+
+  getTask(gid: string): Promise<Record<string, any>> {
+    return this.request('GET', `/tasks/${gid}`, undefined, {
+      opt_fields: 'name,completed,due_on,notes,assignee.gid',
+    })
+  }
+
+  tasksInProject(projectGid: string): Promise<Array<Record<string, any>>> {
+    return this.request('GET', `/projects/${projectGid}/tasks`, undefined, {
+      opt_fields: 'name,completed,due_on,notes,assignee.gid',
+      limit: '100',
+    })
+  }
+
+  stories(taskGid: string): Promise<Array<{ type: string, text: string }>> {
+    return this.request('GET', `/tasks/${taskGid}/stories`, undefined, {
+      opt_fields: 'type,text',
+      limit: '100',
+    })
+  }
+
+  deleteTask(gid: string): Promise<void> {
+    return this.request('DELETE', `/tasks/${gid}`)
+  }
+}

--- a/bench/src/asana.ts
+++ b/bench/src/asana.ts
@@ -44,6 +44,16 @@ export class AsanaClient {
     body?: unknown,
     query?: Record<string, string>,
   ): Promise<T> {
+    const payload = await this.requestRaw<T>(method, path, body, query)
+    return payload.data
+  }
+
+  private async requestRaw<T = any>(
+    method: string,
+    path: string,
+    body?: unknown,
+    query?: Record<string, string>,
+  ): Promise<{ data: T, next_page?: { offset: string } | null }> {
     const url = new URL(API_BASE + path)
     for (const [key, value] of Object.entries(query ?? {})) {
       url.searchParams.set(key, value)
@@ -59,8 +69,7 @@ export class AsanaClient {
     if (!res.ok) {
       throw new Error(`Asana ${method} ${path} → ${res.status}: ${await res.text()}`)
     }
-    const payload = await res.json() as { data: T }
-    return payload.data
+    return await res.json() as { data: T, next_page?: { offset: string } | null }
   }
 
   me(): Promise<{ gid: string, name: string }> {
@@ -98,11 +107,19 @@ export class AsanaClient {
     })
   }
 
-  tasksInProject(projectGid: string): Promise<Array<Record<string, any>>> {
-    return this.request('GET', `/projects/${projectGid}/tasks`, undefined, {
-      opt_fields: 'name,completed,due_on,notes,assignee.gid',
-      limit: '100',
-    })
+  async tasksInProject(projectGid: string): Promise<Array<Record<string, any>>> {
+    const tasks: Array<Record<string, any>> = []
+    let offset: string | undefined
+    do {
+      const page = await this.requestRaw<Array<Record<string, any>>>('GET', `/projects/${projectGid}/tasks`, undefined, {
+        opt_fields: 'name,completed,due_on,notes,assignee.gid',
+        limit: '100',
+        ...(offset ? { offset } : {}),
+      })
+      tasks.push(...page.data)
+      offset = page.next_page?.offset
+    } while (offset)
+    return tasks
   }
 
   stories(taskGid: string): Promise<Array<{ type: string, text: string }>> {

--- a/bench/src/claude.ts
+++ b/bench/src/claude.ts
@@ -29,9 +29,8 @@ export async function runClaude(options: RunClaudeOptions): Promise<ClaudeMetric
   }
 }
 
-async function runClaudeIn(cwd: string, options: RunClaudeOptions): Promise<ClaudeMetrics> {
-  const { prompt, condition, model, maxTurns, timeoutMs } = options
-
+function buildClaudeArgs(options: RunClaudeOptions): string[] {
+  const { prompt, condition, model, maxTurns } = options
   const args = [
     '-p',
     prompt,
@@ -56,6 +55,12 @@ async function runClaudeIn(cwd: string, options: RunClaudeOptions): Promise<Clau
   if (condition.disallowedTools.length > 0) {
     args.push('--disallowedTools', condition.disallowedTools.join(','))
   }
+  return args
+}
+
+async function runClaudeIn(cwd: string, options: RunClaudeOptions): Promise<ClaudeMetrics> {
+  const { condition, timeoutMs } = options
+  const args = buildClaudeArgs(options)
 
   const proc = Bun.spawn(['claude', ...args], {
     cwd,

--- a/bench/src/claude.ts
+++ b/bench/src/claude.ts
@@ -1,0 +1,136 @@
+import type { ClaudeMetrics, Condition } from './types'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+export interface RunClaudeOptions {
+  prompt: string
+  condition: Condition
+  model: string
+  maxTurns: number
+  timeoutMs: number
+}
+
+/**
+ * Runs one headless `claude -p` session and extracts metrics from the
+ * stream-json transcript. The session runs in a fresh temp cwd with only
+ * project-level setting sources so user hooks, memory, and global CLAUDE.md
+ * cannot contaminate the measurement.
+ */
+export async function runClaude(options: RunClaudeOptions): Promise<ClaudeMetrics> {
+  const { prompt, condition, model, maxTurns, timeoutMs } = options
+  const cwd = mkdtempSync(join(tmpdir(), 'asana-bench-'))
+
+  const args = [
+    '-p',
+    prompt,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--model',
+    model,
+    '--max-turns',
+    String(maxTurns),
+    '--setting-sources',
+    'project',
+    '--strict-mcp-config',
+    '--mcp-config',
+    condition.mcpConfigPath,
+    '--append-system-prompt',
+    condition.systemPromptAppend,
+  ]
+  if (condition.allowedTools.length > 0) {
+    args.push('--allowedTools', condition.allowedTools.join(','))
+  }
+  if (condition.disallowedTools.length > 0) {
+    args.push('--disallowedTools', condition.disallowedTools.join(','))
+  }
+
+  const proc = Bun.spawn(['claude', ...args], {
+    cwd,
+    env: { ...process.env, ...condition.env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const timer = setTimeout(() => proc.kill(), timeoutMs)
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  const exitCode = await proc.exited
+  clearTimeout(timer)
+
+  const metrics = parseStream(stdout)
+  if (!metrics) {
+    return {
+      isError: true,
+      subtype: exitCode === null || exitCode !== 0 ? `exit_${exitCode}_or_timeout` : 'no_result_event',
+      numTurns: 0,
+      durationMs: timeoutMs,
+      durationApiMs: 0,
+      costUsd: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      toolCalls: {},
+      totalToolCalls: 0,
+      resultText: stderr.slice(0, 500),
+      sessionId: '',
+    }
+  }
+  return metrics
+}
+
+function parseStream(stdout: string): ClaudeMetrics | null {
+  const toolCalls: Record<string, number> = {}
+  let result: Record<string, any> | null = null
+
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('{')) {
+      continue
+    }
+    let event: Record<string, any>
+    try {
+      event = JSON.parse(trimmed)
+    }
+    catch {
+      continue
+    }
+    if (event.type === 'assistant') {
+      for (const block of event.message?.content ?? []) {
+        if (block.type === 'tool_use') {
+          toolCalls[block.name] = (toolCalls[block.name] ?? 0) + 1
+        }
+      }
+    }
+    else if (event.type === 'result') {
+      result = event
+    }
+  }
+
+  if (!result) {
+    return null
+  }
+
+  const usage = result.usage ?? {}
+  return {
+    isError: Boolean(result.is_error),
+    subtype: result.subtype ?? 'unknown',
+    numTurns: result.num_turns ?? 0,
+    durationMs: result.duration_ms ?? 0,
+    durationApiMs: result.duration_api_ms ?? 0,
+    costUsd: result.total_cost_usd ?? 0,
+    inputTokens: usage.input_tokens ?? 0,
+    outputTokens: usage.output_tokens ?? 0,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+    toolCalls,
+    totalToolCalls: Object.values(toolCalls).reduce((sum, n) => sum + n, 0),
+    resultText: String(result.result ?? '').slice(0, 1000),
+    sessionId: result.session_id ?? '',
+  }
+}

--- a/bench/src/claude.ts
+++ b/bench/src/claude.ts
@@ -1,5 +1,5 @@
 import type { ClaudeMetrics, Condition } from './types'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -19,8 +19,18 @@ export interface RunClaudeOptions {
  * cannot contaminate the measurement.
  */
 export async function runClaude(options: RunClaudeOptions): Promise<ClaudeMetrics> {
-  const { prompt, condition, model, maxTurns, timeoutMs } = options
   const cwd = mkdtempSync(join(tmpdir(), 'asana-bench-'))
+
+  try {
+    return await runClaudeIn(cwd, options)
+  }
+  finally {
+    rmSync(cwd, { recursive: true, force: true })
+  }
+}
+
+async function runClaudeIn(cwd: string, options: RunClaudeOptions): Promise<ClaudeMetrics> {
+  const { prompt, condition, model, maxTurns, timeoutMs } = options
 
   const args = [
     '-p',

--- a/bench/src/conditions.ts
+++ b/bench/src/conditions.ts
@@ -1,0 +1,70 @@
+import type { Condition } from './types'
+import { join } from 'node:path'
+
+const CONDITIONS_DIR = join(import.meta.dir, '..', 'conditions')
+
+/**
+ * Every condition runs the same prompts with the same model; only the tool
+ * surface differs. The system-prompt hint is one symmetric sentence per
+ * condition — enough to know the interface exists, nothing about how to use it.
+ */
+export const CONDITIONS: Condition[] = [
+  {
+    name: 'cli',
+    description: 'pleaseai/asana CLI via Bash (AXI-style output, TOON default)',
+    mcpConfigPath: join(CONDITIONS_DIR, 'cli.json'),
+    allowedTools: ['Bash(asana:*)'],
+    disallowedTools: ['WebFetch', 'WebSearch', 'Task'],
+    env: {},
+    systemPromptAppend: 'The `asana` CLI is installed and already authenticated. Discover commands with `asana --help`.',
+  },
+  {
+    name: 'mcp',
+    description: 'Official Asana MCP (mcp.asana.com) with tool search (deferred schemas)',
+    mcpConfigPath: join(CONDITIONS_DIR, 'mcp.json'),
+    allowedTools: ['mcp__asana'],
+    disallowedTools: ['Bash', 'WebFetch', 'WebSearch', 'Task'],
+    env: { ENABLE_TOOL_SEARCH: 'auto' },
+    systemPromptAppend: 'Asana MCP tools are connected and already authenticated.',
+  },
+  {
+    name: 'mcp-eager',
+    description: 'Official Asana MCP with all tool schemas loaded upfront (tool search off)',
+    mcpConfigPath: join(CONDITIONS_DIR, 'mcp.json'),
+    allowedTools: ['mcp__asana'],
+    disallowedTools: ['Bash', 'WebFetch', 'WebSearch', 'Task'],
+    env: { ENABLE_TOOL_SEARCH: 'false' },
+    systemPromptAppend: 'Asana MCP tools are connected and already authenticated.',
+  },
+  {
+    name: 'executor',
+    description: 'executor.sh hosted MCP proxy (code-mode) via https://executor.sh/<org>/mcp',
+    mcpConfigPath: join(CONDITIONS_DIR, 'executor.json'),
+    allowedTools: ['mcp__executor'],
+    disallowedTools: ['Bash', 'WebFetch', 'WebSearch', 'Task'],
+    env: {},
+    systemPromptAppend: 'The Executor MCP proxy is connected; it exposes Asana and is already authenticated.',
+  },
+  {
+    name: 'executor-cli',
+    description: 'executor.sh local proxy driven through its CLI (`executor tools search` / `executor call`) via Bash',
+    mcpConfigPath: join(CONDITIONS_DIR, 'cli.json'),
+    allowedTools: ['Bash(executor:*)'],
+    disallowedTools: ['WebFetch', 'WebSearch', 'Task'],
+    env: {},
+    systemPromptAppend: 'The `executor` CLI is installed and its local service is running with Asana connected. Discover tools with `executor tools search <query>` and invoke them with `executor call <server> <tool> <json-args>`.',
+  },
+]
+
+export function resolveConditions(names?: string[]): Condition[] {
+  if (!names || names.length === 0) {
+    return CONDITIONS.filter(c => !['mcp-eager', 'executor-cli'].includes(c.name))
+  }
+  return names.map((name) => {
+    const condition = CONDITIONS.find(c => c.name === name)
+    if (!condition) {
+      throw new Error(`Unknown condition "${name}". Available: ${CONDITIONS.map(c => c.name).join(', ')}`)
+    }
+    return condition
+  })
+}

--- a/bench/src/report.ts
+++ b/bench/src/report.ts
@@ -19,8 +19,14 @@ async function loadRecords(files: string[]): Promise<RunRecord[]> {
   for (const file of files) {
     const text = await Bun.file(file).text()
     for (const line of text.split('\n')) {
-      if (line.trim()) {
+      if (!line.trim()) {
+        continue
+      }
+      try {
         records.push(JSON.parse(line))
+      }
+      catch {
+        console.warn(`skipping malformed line in ${file}: ${line.slice(0, 80)}`)
       }
     }
   }

--- a/bench/src/report.ts
+++ b/bench/src/report.ts
@@ -1,0 +1,97 @@
+import type { RunRecord } from './types'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+
+const RESULTS_DIR = join(import.meta.dir, '..', 'results')
+
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0
+  }
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2 : (sorted[mid] ?? 0)
+}
+
+async function loadRecords(files: string[]): Promise<RunRecord[]> {
+  const records: RunRecord[] = []
+  for (const file of files) {
+    const text = await Bun.file(file).text()
+    for (const line of text.split('\n')) {
+      if (line.trim()) {
+        records.push(JSON.parse(line))
+      }
+    }
+  }
+  return records
+}
+
+function summarize(records: RunRecord[]) {
+  return {
+    n: records.length,
+    successRate: records.filter(r => r.success).length / records.length,
+    costUsd: median(records.map(r => r.costUsd)),
+    durationS: median(records.map(r => r.durationMs)) / 1000,
+    turns: median(records.map(r => r.numTurns)),
+    toolCalls: median(records.map(r => r.totalToolCalls)),
+    inputTokens: median(records.map(r => r.inputTokens + r.cacheCreationTokens + r.cacheReadTokens)),
+    outputTokens: median(records.map(r => r.outputTokens)),
+  }
+}
+
+function row(name: string, s: ReturnType<typeof summarize>): string {
+  return `| ${name} | ${s.n} | ${(s.successRate * 100).toFixed(0)}% | $${s.costUsd.toFixed(4)} | ${s.durationS.toFixed(1)}s | ${s.turns} | ${s.toolCalls} | ${Math.round(s.inputTokens).toLocaleString()} | ${Math.round(s.outputTokens).toLocaleString()} |`
+}
+
+const HEADER = `| condition | n | success | cost (med) | time (med) | turns | tool calls | input tok (med) | output tok (med) |
+|---|---|---|---|---|---|---|---|---|`
+
+export async function printReport(files: string[]): Promise<void> {
+  const records = await loadRecords(files)
+  if (records.length === 0) {
+    console.log('No records found.')
+    return
+  }
+
+  const conditions = [...new Set(records.map(r => r.condition))]
+  const tasks = [...new Set(records.map(r => r.task))]
+
+  console.log(`# Asana interface benchmark — ${records.length} runs, model ${[...new Set(records.map(r => r.model))].join('/')}\n`)
+
+  console.log('## Overall (all tasks)\n')
+  console.log(HEADER)
+  for (const condition of conditions) {
+    console.log(row(condition, summarize(records.filter(r => r.condition === condition))))
+  }
+
+  for (const task of tasks) {
+    console.log(`\n## Task: ${task}\n`)
+    console.log(HEADER)
+    for (const condition of conditions) {
+      const subset = records.filter(r => r.condition === condition && r.task === task)
+      if (subset.length > 0) {
+        console.log(row(condition, summarize(subset)))
+      }
+    }
+  }
+
+  const failures = records.filter(r => !r.success)
+  if (failures.length > 0) {
+    console.log('\n## Failures\n')
+    for (const failure of failures) {
+      console.log(`- ${failure.task} × ${failure.condition} #${failure.iteration}: ${failure.verifyDetail}`)
+    }
+  }
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2)
+  const files = args.length > 0
+    ? args
+    : readdirSync(RESULTS_DIR).filter(f => f.endsWith('.jsonl')).map(f => join(RESULTS_DIR, f))
+  printReport(files).catch((err) => {
+    console.error(err)
+    process.exitCode = 1
+  })
+}

--- a/bench/src/report.ts
+++ b/bench/src/report.ts
@@ -1,5 +1,5 @@
 import type { RunRecord } from './types'
-import { readdirSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
 
@@ -95,7 +95,9 @@ if (import.meta.main) {
   const args = process.argv.slice(2)
   const files = args.length > 0
     ? args
-    : readdirSync(RESULTS_DIR).filter(f => f.endsWith('.jsonl')).map(f => join(RESULTS_DIR, f))
+    : existsSync(RESULTS_DIR)
+      ? readdirSync(RESULTS_DIR).filter(f => f.endsWith('.jsonl')).map(f => join(RESULTS_DIR, f))
+      : []
   printReport(files).catch((err) => {
     console.error(err)
     process.exitCode = 1

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -92,40 +92,43 @@ async function main(): Promise<void> {
         console.log(`${label} — seeding (${prefix})`)
         const seededGids = await task.seed(ctx)
 
-        console.log(`${label} — running claude`)
-        const metrics = await runClaude({
-          prompt: task.prompt(ctx),
-          condition,
-          model,
-          maxTurns,
-          timeoutMs,
-        })
+        try {
+          console.log(`${label} — running claude`)
+          const metrics = await runClaude({
+            prompt: task.prompt(ctx),
+            condition,
+            model,
+            maxTurns,
+            timeoutMs,
+          })
 
-        const verdict = metrics.isError
-          ? { success: false, detail: `claude error: ${metrics.subtype}` }
-          : await task.verify(ctx, metrics.resultText)
+          const verdict = metrics.isError
+            ? { success: false, detail: `claude error: ${metrics.subtype}` }
+            : await task.verify(ctx, metrics.resultText)
 
-        const record: RunRecord = {
-          timestamp: new Date().toISOString(),
-          session,
-          condition: condition.name,
-          task: task.id,
-          iteration,
-          model,
-          success: verdict.success,
-          verifyDetail: verdict.detail,
-          ...metrics,
+          const record: RunRecord = {
+            timestamp: new Date().toISOString(),
+            session,
+            condition: condition.name,
+            task: task.id,
+            iteration,
+            model,
+            success: verdict.success,
+            verifyDetail: verdict.detail,
+            ...metrics,
+          }
+          appendFileSync(resultsFile, `${JSON.stringify(record)}\n`)
+
+          const status = verdict.success ? 'PASS' : 'FAIL'
+          console.log(`${label} — ${status} | $${metrics.costUsd.toFixed(4)} | ${(metrics.durationMs / 1000).toFixed(1)}s | ${metrics.numTurns} turns | ${metrics.totalToolCalls} tool calls`)
+          if (!verdict.success) {
+            console.log(`${label} — detail: ${verdict.detail}`)
+          }
         }
-        appendFileSync(resultsFile, `${JSON.stringify(record)}\n`)
-
-        const status = verdict.success ? 'PASS' : 'FAIL'
-        console.log(`${label} — ${status} | $${metrics.costUsd.toFixed(4)} | ${(metrics.durationMs / 1000).toFixed(1)}s | ${metrics.numTurns} turns | ${metrics.totalToolCalls} tool calls`)
-        if (!verdict.success) {
-          console.log(`${label} — detail: ${verdict.detail}`)
-        }
-
-        if (!values['keep-tasks']) {
-          await cleanup(client, ctx, seededGids)
+        finally {
+          if (!values['keep-tasks']) {
+            await cleanup(client, ctx, seededGids)
+          }
         }
       }
     }

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -198,7 +198,7 @@ async function createBenchProject(client: AsanaClient, workspaceGid: string, ses
 
 async function cleanup(client: AsanaClient, ctx: BenchContext, seededGids: string[]): Promise<void> {
   const gids = new Set(seededGids)
-  const remaining = await client.tasksInProject(ctx.projectGid).catch(() => [] as Awaited<ReturnType<AsanaClient['tasksInProject']>>)
+  const remaining = await client.tasksInProject(ctx.projectGid).catch(() => [])
   for (const task of remaining) {
     if (typeof task.name === 'string' && task.name.startsWith(ctx.prefix)) {
       gids.add(task.gid)

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -1,4 +1,4 @@
-import type { BenchContext, RunRecord } from './types'
+import type { BenchContext, BenchTask, Condition, RunRecord } from './types'
 import { randomUUID } from 'node:crypto'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
@@ -12,7 +12,21 @@ import { resolveTasks } from './tasks'
 
 const RESULTS_DIR = join(import.meta.dir, '..', 'results')
 
-async function main(): Promise<void> {
+interface CliOptions {
+  conditions: Condition[]
+  tasks: BenchTask[]
+  runs: number
+  model: string
+  maxTurns: number
+  timeoutMs: number
+  session: string
+  workspace?: string
+  project?: string
+  keepTasks: boolean
+  dryRun: boolean
+}
+
+function parseCliOptions(): CliOptions {
   const { values } = parseArgs({
     options: {
       'conditions': { type: 'string' },
@@ -29,8 +43,6 @@ async function main(): Promise<void> {
     },
   })
 
-  const conditions = resolveConditions(values.conditions?.split(','))
-  const tasks = resolveTasks(values.tasks?.split(','))
   const runs = Number(values.runs)
   const maxTurns = Number(values['max-turns'])
   const timeoutMinutes = Number(values['timeout-min'])
@@ -43,99 +55,134 @@ async function main(): Promise<void> {
   if (!Number.isFinite(timeoutMinutes) || timeoutMinutes <= 0) {
     throw new Error(`Invalid --timeout-min value: ${values['timeout-min']}`)
   }
-  const model = values.model!
-  const timeoutMs = timeoutMinutes * 60_000
-  const session = values.session ?? new Date().toISOString().replace(/[:T]/g, '-').slice(0, 16)
 
-  const client = await AsanaClient.create()
-  const me = await client.me()
+  return {
+    conditions: resolveConditions(values.conditions?.split(',')),
+    tasks: resolveTasks(values.tasks?.split(',')),
+    runs,
+    model: values.model!,
+    maxTurns,
+    timeoutMs: timeoutMinutes * 60_000,
+    session: values.session ?? new Date().toISOString().replace(/[:T]/g, '-').slice(0, 16),
+    workspace: values.workspace,
+    project: values.project ?? process.env.BENCH_PROJECT_GID,
+    keepTasks: values['keep-tasks']!,
+    dryRun: values['dry-run']!,
+  }
+}
 
+async function resolveWorkspace(
+  client: AsanaClient,
+  requested?: string,
+): Promise<{ workspaceGid: string, workspaceName: string }> {
   const workspaces = await client.workspaces()
-  const workspaceGid = values.workspace ?? process.env.BENCH_WORKSPACE_GID ?? workspaces[0]?.gid
+  const workspaceGid = requested ?? process.env.BENCH_WORKSPACE_GID ?? workspaces[0]?.gid
   if (!workspaceGid) {
     throw new Error('No Asana workspace available')
   }
-  const workspaceName = workspaces.find(w => w.gid === workspaceGid)?.name ?? workspaceGid
+  return {
+    workspaceGid,
+    workspaceName: workspaces.find(w => w.gid === workspaceGid)?.name ?? workspaceGid,
+  }
+}
 
-  const givenProject = values.project ?? process.env.BENCH_PROJECT_GID
+async function main(): Promise<void> {
+  const opts = parseCliOptions()
+  const client = await AsanaClient.create()
+  const me = await client.me()
+  const { workspaceGid, workspaceName } = await resolveWorkspace(client, opts.workspace)
 
-  if (values['dry-run']) {
-    console.log(`session=${session} model=${model} workspace=${workspaceName} project=${givenProject ?? '(would create a new bench project)'}`)
-    console.log(`conditions=[${conditions.map(c => c.name).join(', ')}] tasks=[${tasks.map(t => t.id).join(', ')}] runs=${runs}`)
+  if (opts.dryRun) {
+    console.log(`session=${opts.session} model=${opts.model} workspace=${workspaceName} project=${opts.project ?? '(would create a new bench project)'}`)
+    console.log(`conditions=[${opts.conditions.map(c => c.name).join(', ')}] tasks=[${opts.tasks.map(t => t.id).join(', ')}] runs=${opts.runs}`)
     console.log('Dry run — no sessions started.')
     return
   }
 
-  const projectGid = givenProject ?? await createBenchProject(client, workspaceGid, session)
+  const projectGid = opts.project ?? await createBenchProject(client, workspaceGid, opts.session)
   const projectName = (await client.getProject(projectGid)).name
 
-  console.log(`session=${session} model=${model} workspace=${workspaceName} project=${projectName}`)
-  console.log(`conditions=[${conditions.map(c => c.name).join(', ')}] tasks=[${tasks.map(t => t.id).join(', ')}] runs=${runs}`)
+  console.log(`session=${opts.session} model=${opts.model} workspace=${workspaceName} project=${projectName}`)
+  console.log(`conditions=[${opts.conditions.map(c => c.name).join(', ')}] tasks=[${opts.tasks.map(t => t.id).join(', ')}] runs=${opts.runs}`)
 
   mkdirSync(RESULTS_DIR, { recursive: true })
-  const resultsFile = join(RESULTS_DIR, `${session}.jsonl`)
+  const resultsFile = join(RESULTS_DIR, `${opts.session}.jsonl`)
 
-  for (let iteration = 1; iteration <= runs; iteration++) {
-    for (const task of tasks) {
-      for (const condition of conditions) {
-        const prefix = `BM-${randomUUID().slice(0, 5)}`
-        const ctx: BenchContext = {
-          prefix,
-          workspaceGid,
-          workspaceName,
-          projectGid,
-          projectName,
-          meGid: me.gid,
-        }
+  const base = { workspaceGid, workspaceName, projectGid, projectName, meGid: me.gid }
+  await runBenchmarkLoop(client, base, opts, resultsFile)
 
-        const label = `[${iteration}/${runs}] ${task.id} × ${condition.name}`
-        console.log(`${label} — seeding (${prefix})`)
+  console.log(`\nResults written to ${resultsFile}\n`)
+  await printReport([resultsFile])
+}
+
+async function runBenchmarkLoop(
+  client: AsanaClient,
+  base: Omit<BenchContext, 'prefix'>,
+  opts: CliOptions,
+  resultsFile: string,
+): Promise<void> {
+  for (let iteration = 1; iteration <= opts.runs; iteration++) {
+    for (const task of opts.tasks) {
+      for (const condition of opts.conditions) {
+        const ctx: BenchContext = { prefix: `BM-${randomUUID().slice(0, 5)}`, ...base }
+        const label = `[${iteration}/${opts.runs}] ${task.id} × ${condition.name}`
+        console.log(`${label} — seeding (${ctx.prefix})`)
         const seededGids = await task.seed(ctx)
-
         try {
-          console.log(`${label} — running claude`)
-          const metrics = await runClaude({
-            prompt: task.prompt(ctx),
-            condition,
-            model,
-            maxTurns,
-            timeoutMs,
-          })
-
-          const verdict = metrics.isError
-            ? { success: false, detail: `claude error: ${metrics.subtype}` }
-            : await task.verify(ctx, metrics.resultText)
-
-          const record: RunRecord = {
-            timestamp: new Date().toISOString(),
-            session,
-            condition: condition.name,
-            task: task.id,
-            iteration,
-            model,
-            success: verdict.success,
-            verifyDetail: verdict.detail,
-            ...metrics,
-          }
-          appendFileSync(resultsFile, `${JSON.stringify(record)}\n`)
-
-          const status = verdict.success ? 'PASS' : 'FAIL'
-          console.log(`${label} — ${status} | $${metrics.costUsd.toFixed(4)} | ${(metrics.durationMs / 1000).toFixed(1)}s | ${metrics.numTurns} turns | ${metrics.totalToolCalls} tool calls`)
-          if (!verdict.success) {
-            console.log(`${label} — detail: ${verdict.detail}`)
-          }
+          await executeRun({ ctx, task, condition, opts, resultsFile, label, iteration })
         }
         finally {
-          if (!values['keep-tasks']) {
+          if (!opts.keepTasks) {
             await cleanup(client, ctx, seededGids)
           }
         }
       }
     }
   }
+}
 
-  console.log(`\nResults written to ${resultsFile}\n`)
-  await printReport([resultsFile])
+interface RunParams {
+  ctx: BenchContext
+  task: BenchTask
+  condition: Condition
+  opts: CliOptions
+  resultsFile: string
+  label: string
+  iteration: number
+}
+
+async function executeRun({ ctx, task, condition, opts, resultsFile, label, iteration }: RunParams): Promise<void> {
+  console.log(`${label} — running claude`)
+  const metrics = await runClaude({
+    prompt: task.prompt(ctx),
+    condition,
+    model: opts.model,
+    maxTurns: opts.maxTurns,
+    timeoutMs: opts.timeoutMs,
+  })
+
+  const verdict = metrics.isError
+    ? { success: false, detail: `claude error: ${metrics.subtype}` }
+    : await task.verify(ctx, metrics.resultText)
+
+  const record: RunRecord = {
+    timestamp: new Date().toISOString(),
+    session: opts.session,
+    condition: condition.name,
+    task: task.id,
+    iteration,
+    model: opts.model,
+    success: verdict.success,
+    verifyDetail: verdict.detail,
+    ...metrics,
+  }
+  appendFileSync(resultsFile, `${JSON.stringify(record)}\n`)
+
+  const status = verdict.success ? 'PASS' : 'FAIL'
+  console.log(`${label} — ${status} | $${metrics.costUsd.toFixed(4)} | ${(metrics.durationMs / 1000).toFixed(1)}s | ${metrics.numTurns} turns | ${metrics.totalToolCalls} tool calls`)
+  if (!verdict.success) {
+    console.log(`${label} — detail: ${verdict.detail}`)
+  }
 }
 
 async function createBenchProject(client: AsanaClient, workspaceGid: string, session: string): Promise<string> {

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -143,11 +143,11 @@ async function cleanup(client: AsanaClient, ctx: BenchContext, seededGids: strin
       gids.add(task.gid)
     }
   }
-  for (const gid of gids) {
-    await client.deleteTask(gid).catch((err: Error) =>
+  await Promise.all([...gids].map(gid =>
+    client.deleteTask(gid).catch((err: Error) =>
       console.warn(`cleanup: failed to delete ${gid}: ${err.message}`),
-    )
-  }
+    ),
+  ))
 }
 
 main().catch((err) => {

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -1,4 +1,5 @@
 import type { BenchContext, RunRecord } from './types'
+import { randomUUID } from 'node:crypto'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -31,9 +32,19 @@ async function main(): Promise<void> {
   const conditions = resolveConditions(values.conditions?.split(','))
   const tasks = resolveTasks(values.tasks?.split(','))
   const runs = Number(values.runs)
-  const model = values.model!
   const maxTurns = Number(values['max-turns'])
-  const timeoutMs = Number(values['timeout-min']) * 60_000
+  const timeoutMinutes = Number(values['timeout-min'])
+  if (!Number.isInteger(runs) || runs < 1) {
+    throw new Error(`Invalid --runs value: ${values.runs}`)
+  }
+  if (!Number.isFinite(maxTurns) || maxTurns < 1) {
+    throw new Error(`Invalid --max-turns value: ${values['max-turns']}`)
+  }
+  if (!Number.isFinite(timeoutMinutes) || timeoutMinutes <= 0) {
+    throw new Error(`Invalid --timeout-min value: ${values['timeout-min']}`)
+  }
+  const model = values.model!
+  const timeoutMs = timeoutMinutes * 60_000
   const session = values.session ?? new Date().toISOString().replace(/[:T]/g, '-').slice(0, 16)
 
   const client = await AsanaClient.create()
@@ -67,7 +78,7 @@ async function main(): Promise<void> {
   for (let iteration = 1; iteration <= runs; iteration++) {
     for (const task of tasks) {
       for (const condition of conditions) {
-        const prefix = `BM-${Math.random().toString(36).slice(2, 7)}`
+        const prefix = `BM-${randomUUID().slice(0, 5)}`
         const ctx: BenchContext = {
           prefix,
           workspaceGid,

--- a/bench/src/run.ts
+++ b/bench/src/run.ts
@@ -1,0 +1,156 @@
+import type { BenchContext, RunRecord } from './types'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+import { AsanaClient } from './asana'
+import { runClaude } from './claude'
+import { resolveConditions } from './conditions'
+import { printReport } from './report'
+import { resolveTasks } from './tasks'
+
+const RESULTS_DIR = join(import.meta.dir, '..', 'results')
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      'conditions': { type: 'string' },
+      'tasks': { type: 'string' },
+      'runs': { type: 'string', default: '3' },
+      'model': { type: 'string', default: 'sonnet' },
+      'workspace': { type: 'string' },
+      'project': { type: 'string' },
+      'session': { type: 'string' },
+      'max-turns': { type: 'string', default: '40' },
+      'timeout-min': { type: 'string', default: '10' },
+      'keep-tasks': { type: 'boolean', default: false },
+      'dry-run': { type: 'boolean', default: false },
+    },
+  })
+
+  const conditions = resolveConditions(values.conditions?.split(','))
+  const tasks = resolveTasks(values.tasks?.split(','))
+  const runs = Number(values.runs)
+  const model = values.model!
+  const maxTurns = Number(values['max-turns'])
+  const timeoutMs = Number(values['timeout-min']) * 60_000
+  const session = values.session ?? new Date().toISOString().replace(/[:T]/g, '-').slice(0, 16)
+
+  const client = await AsanaClient.create()
+  const me = await client.me()
+
+  const workspaces = await client.workspaces()
+  const workspaceGid = values.workspace ?? process.env.BENCH_WORKSPACE_GID ?? workspaces[0]?.gid
+  if (!workspaceGid) {
+    throw new Error('No Asana workspace available')
+  }
+  const workspaceName = workspaces.find(w => w.gid === workspaceGid)?.name ?? workspaceGid
+
+  const givenProject = values.project ?? process.env.BENCH_PROJECT_GID
+
+  if (values['dry-run']) {
+    console.log(`session=${session} model=${model} workspace=${workspaceName} project=${givenProject ?? '(would create a new bench project)'}`)
+    console.log(`conditions=[${conditions.map(c => c.name).join(', ')}] tasks=[${tasks.map(t => t.id).join(', ')}] runs=${runs}`)
+    console.log('Dry run — no sessions started.')
+    return
+  }
+
+  const projectGid = givenProject ?? await createBenchProject(client, workspaceGid, session)
+  const projectName = (await client.getProject(projectGid)).name
+
+  console.log(`session=${session} model=${model} workspace=${workspaceName} project=${projectName}`)
+  console.log(`conditions=[${conditions.map(c => c.name).join(', ')}] tasks=[${tasks.map(t => t.id).join(', ')}] runs=${runs}`)
+
+  mkdirSync(RESULTS_DIR, { recursive: true })
+  const resultsFile = join(RESULTS_DIR, `${session}.jsonl`)
+
+  for (let iteration = 1; iteration <= runs; iteration++) {
+    for (const task of tasks) {
+      for (const condition of conditions) {
+        const prefix = `BM-${Math.random().toString(36).slice(2, 7)}`
+        const ctx: BenchContext = {
+          prefix,
+          workspaceGid,
+          workspaceName,
+          projectGid,
+          projectName,
+          meGid: me.gid,
+        }
+
+        const label = `[${iteration}/${runs}] ${task.id} × ${condition.name}`
+        console.log(`${label} — seeding (${prefix})`)
+        const seededGids = await task.seed(ctx)
+
+        console.log(`${label} — running claude`)
+        const metrics = await runClaude({
+          prompt: task.prompt(ctx),
+          condition,
+          model,
+          maxTurns,
+          timeoutMs,
+        })
+
+        const verdict = metrics.isError
+          ? { success: false, detail: `claude error: ${metrics.subtype}` }
+          : await task.verify(ctx, metrics.resultText)
+
+        const record: RunRecord = {
+          timestamp: new Date().toISOString(),
+          session,
+          condition: condition.name,
+          task: task.id,
+          iteration,
+          model,
+          success: verdict.success,
+          verifyDetail: verdict.detail,
+          ...metrics,
+        }
+        appendFileSync(resultsFile, `${JSON.stringify(record)}\n`)
+
+        const status = verdict.success ? 'PASS' : 'FAIL'
+        console.log(`${label} — ${status} | $${metrics.costUsd.toFixed(4)} | ${(metrics.durationMs / 1000).toFixed(1)}s | ${metrics.numTurns} turns | ${metrics.totalToolCalls} tool calls`)
+        if (!verdict.success) {
+          console.log(`${label} — detail: ${verdict.detail}`)
+        }
+
+        if (!values['keep-tasks']) {
+          await cleanup(client, ctx, seededGids)
+        }
+      }
+    }
+  }
+
+  console.log(`\nResults written to ${resultsFile}\n`)
+  await printReport([resultsFile])
+}
+
+async function createBenchProject(client: AsanaClient, workspaceGid: string, session: string): Promise<string> {
+  const teams = await client.myTeams(workspaceGid).catch(() => [])
+  const project = await client.createProject(
+    workspaceGid,
+    `Interface Bench ${session}`,
+    teams[0]?.gid,
+  )
+  console.log(`Created bench project "${project.name}" (${project.gid}) — reuse it with --project ${project.gid}`)
+  return project.gid
+}
+
+async function cleanup(client: AsanaClient, ctx: BenchContext, seededGids: string[]): Promise<void> {
+  const gids = new Set(seededGids)
+  const remaining = await client.tasksInProject(ctx.projectGid).catch(() => [] as Awaited<ReturnType<AsanaClient['tasksInProject']>>)
+  for (const task of remaining) {
+    if (typeof task.name === 'string' && task.name.startsWith(ctx.prefix)) {
+      gids.add(task.gid)
+    }
+  }
+  for (const gid of gids) {
+    await client.deleteTask(gid).catch((err: Error) =>
+      console.warn(`cleanup: failed to delete ${gid}: ${err.message}`),
+    )
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/bench/src/tasks.ts
+++ b/bench/src/tasks.ts
@@ -1,0 +1,178 @@
+import type { BenchContext, BenchTask, VerifyResult } from './types'
+import { AsanaClient } from './asana'
+
+function pass(detail: string): VerifyResult {
+  return { success: true, detail }
+}
+
+function fail(detail: string): VerifyResult {
+  return { success: false, detail }
+}
+
+async function findByName(client: AsanaClient, ctx: BenchContext, name: string) {
+  const tasks = await client.tasksInProject(ctx.projectGid)
+  return tasks.find(t => t.name === name)
+}
+
+/**
+ * T1 — single read: locate one task and extract a field.
+ * Measures discovery cost (workspace → project → task) plus one read.
+ */
+const readLookup: BenchTask = {
+  id: 'read_lookup',
+  description: 'Find a task by name and report its due date',
+  async seed(ctx) {
+    const client = await AsanaClient.create()
+    const task = await client.createTask({
+      name: `${ctx.prefix} Fix login flow`,
+      notes: 'Reported by QA. Login form rejects valid credentials.',
+      due_on: '2026-07-20',
+      projects: [ctx.projectGid],
+    })
+    return [task.gid]
+  },
+  prompt(ctx) {
+    return `In the Asana workspace "${ctx.workspaceName}", project "${ctx.projectName}", find the task named "${ctx.prefix} Fix login flow" and reply with exactly its due date in YYYY-MM-DD format and nothing else.`
+  },
+  async verify(_ctx, resultText) {
+    if (resultText.includes('2026-07-20')) {
+      return pass('due date 2026-07-20 present in answer')
+    }
+    return fail(`expected 2026-07-20 in answer, got: ${resultText.slice(0, 200)}`)
+  },
+}
+
+/**
+ * T2 — single write: create a task with several fields set.
+ * Verified against ground truth, not against the agent's claim.
+ */
+const writeCreate: BenchTask = {
+  id: 'write_create',
+  description: 'Create a task with name, due date, and notes',
+  async seed() {
+    return []
+  },
+  prompt(ctx) {
+    return `In the Asana workspace "${ctx.workspaceName}", project "${ctx.projectName}", create a task named "${ctx.prefix} Release checklist" with due date 2026-07-25 and notes "Created by interface benchmark". Reply "done" when finished.`
+  },
+  async verify(ctx) {
+    const client = await AsanaClient.create()
+    const task = await findByName(client, ctx, `${ctx.prefix} Release checklist`)
+    if (!task) {
+      return fail('task not found in project')
+    }
+    if (task.due_on !== '2026-07-25') {
+      return fail(`due_on is ${task.due_on}, expected 2026-07-25`)
+    }
+    if (!String(task.notes ?? '').includes('benchmark')) {
+      return fail(`notes missing "benchmark": ${String(task.notes).slice(0, 100)}`)
+    }
+    return pass(`task ${task.gid} created with correct fields`)
+  },
+}
+
+/**
+ * T3 — multi-step mutation: find a task among siblings, complete it,
+ * and add a comment. Measures chained read → write → write.
+ */
+const multiStep: BenchTask = {
+  id: 'multi_step',
+  description: 'Complete a specific task and add a comment',
+  async seed(ctx) {
+    const client = await AsanaClient.create()
+    const names = ['Deploy hotfix', 'Update docs', 'Refactor auth']
+    const gids: string[] = []
+    for (const name of names) {
+      const task = await client.createTask({
+        name: `${ctx.prefix} ${name}`,
+        projects: [ctx.projectGid],
+      })
+      gids.push(task.gid)
+    }
+    return gids
+  },
+  prompt(ctx) {
+    return `In the Asana workspace "${ctx.workspaceName}", project "${ctx.projectName}", find the incomplete task named "${ctx.prefix} Deploy hotfix", mark it complete, and add the comment "Completed via benchmark." to it. Reply "done" when finished.`
+  },
+  async verify(ctx) {
+    const client = await AsanaClient.create()
+    const task = await findByName(client, ctx, `${ctx.prefix} Deploy hotfix`)
+    if (!task) {
+      return fail('target task not found')
+    }
+    if (!task.completed) {
+      return fail('task is not completed')
+    }
+    const stories = await client.stories(task.gid)
+    const comment = stories.find(s => s.type === 'comment' && s.text?.includes('Completed via benchmark'))
+    if (!comment) {
+      return fail('comment "Completed via benchmark." not found')
+    }
+    return pass(`task ${task.gid} completed with comment`)
+  },
+}
+
+/**
+ * T4 — aggregation: count tasks across two dimensions and answer as JSON.
+ * Measures how well the interface supports scanning + client-side reasoning.
+ */
+const aggregate: BenchTask = {
+  id: 'aggregate',
+  description: 'Count incomplete tasks by assignment and answer as JSON',
+  async seed(ctx) {
+    const client = await AsanaClient.create()
+    const gids: string[] = []
+    const specs = [
+      { name: 'Ship v2 API', assignee: ctx.meGid, completed: false },
+      { name: 'Review PR queue', assignee: ctx.meGid, completed: false },
+      { name: 'Write onboarding doc', assignee: null, completed: false },
+      { name: 'Clean stale branches', assignee: null, completed: false },
+      { name: 'Archive old sprint', assignee: null, completed: true },
+    ]
+    for (const spec of specs) {
+      const task = await client.createTask({
+        name: `${ctx.prefix} ${spec.name}`,
+        projects: [ctx.projectGid],
+        completed: spec.completed,
+        ...(spec.assignee ? { assignee: spec.assignee } : {}),
+      })
+      gids.push(task.gid)
+    }
+    return gids
+  },
+  prompt(ctx) {
+    return `In the Asana workspace "${ctx.workspaceName}", project "${ctx.projectName}", consider only tasks whose name starts with "${ctx.prefix}". Among the INCOMPLETE ones, count how many are assigned to me (the authenticated user) and how many are unassigned. Reply with ONLY this JSON and nothing else: {"assigned_to_me": <n>, "unassigned": <n>}`
+  },
+  async verify(_ctx, resultText) {
+    const match = resultText.match(/\{[^{}]*"assigned_to_me"[^{}]*\}/)
+    if (!match) {
+      return fail(`no JSON answer found in: ${resultText.slice(0, 200)}`)
+    }
+    let parsed: { assigned_to_me?: number, unassigned?: number }
+    try {
+      parsed = JSON.parse(match[0])
+    }
+    catch {
+      return fail(`unparseable JSON: ${match[0]}`)
+    }
+    if (parsed.assigned_to_me === 2 && parsed.unassigned === 2) {
+      return pass('counts correct (2 assigned, 2 unassigned)')
+    }
+    return fail(`expected {assigned_to_me:2, unassigned:2}, got ${match[0]}`)
+  },
+}
+
+export const TASKS: BenchTask[] = [readLookup, writeCreate, multiStep, aggregate]
+
+export function resolveTasks(ids?: string[]): BenchTask[] {
+  if (!ids || ids.length === 0) {
+    return TASKS
+  }
+  return ids.map((id) => {
+    const task = TASKS.find(t => t.id === id)
+    if (!task) {
+      throw new Error(`Unknown task "${id}". Available: ${TASKS.map(t => t.id).join(', ')}`)
+    }
+    return task
+  })
+}

--- a/bench/src/tasks.ts
+++ b/bench/src/tasks.ts
@@ -35,10 +35,10 @@ const readLookup: BenchTask = {
     return `In the Asana workspace "${ctx.workspaceName}", project "${ctx.projectName}", find the task named "${ctx.prefix} Fix login flow" and reply with exactly its due date in YYYY-MM-DD format and nothing else.`
   },
   async verify(_ctx, resultText) {
-    if (resultText.includes('2026-07-20')) {
-      return pass('due date 2026-07-20 present in answer')
+    if (resultText.trim() === '2026-07-20') {
+      return pass('answer is exactly the due date 2026-07-20')
     }
-    return fail(`expected 2026-07-20 in answer, got: ${resultText.slice(0, 200)}`)
+    return fail(`expected exactly "2026-07-20", got: ${resultText.slice(0, 200)}`)
   },
 }
 

--- a/bench/src/types.ts
+++ b/bench/src/types.ts
@@ -1,0 +1,67 @@
+export interface Condition {
+  /** short id used in results and CLI args */
+  name: string
+  description: string
+  /** absolute path to the --mcp-config file for this condition */
+  mcpConfigPath: string
+  allowedTools: string[]
+  disallowedTools: string[]
+  /** extra env vars for the claude process (e.g. ENABLE_TOOL_SEARCH) */
+  env: Record<string, string>
+  /** one-line hint appended to the system prompt — keep symmetric across conditions */
+  systemPromptAppend: string
+}
+
+export interface BenchContext {
+  /** unique per-run prefix baked into every seeded/created task name */
+  prefix: string
+  workspaceGid: string
+  workspaceName: string
+  projectGid: string
+  projectName: string
+  /** authenticated user gid (for assignee seeding/verification) */
+  meGid: string
+}
+
+export interface VerifyResult {
+  success: boolean
+  detail: string
+}
+
+export interface BenchTask {
+  id: string
+  description: string
+  /** create fixture state; returns gids of seeded tasks for cleanup */
+  seed: (ctx: BenchContext) => Promise<string[]>
+  prompt: (ctx: BenchContext) => string
+  /** check ground truth via the Asana REST API (never via the interface under test) */
+  verify: (ctx: BenchContext, resultText: string) => Promise<VerifyResult>
+}
+
+export interface ClaudeMetrics {
+  isError: boolean
+  subtype: string
+  numTurns: number
+  durationMs: number
+  durationApiMs: number
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  toolCalls: Record<string, number>
+  totalToolCalls: number
+  resultText: string
+  sessionId: string
+}
+
+export interface RunRecord extends ClaudeMetrics {
+  timestamp: string
+  session: string
+  condition: string
+  task: string
+  iteration: number
+  model: string
+  success: boolean
+  verifyDetail: string
+}


### PR DESCRIPTION
## What

Adds `bench/` — a self-contained benchmark harness that measures **cost, latency, and success rate** when an agent performs identical Asana tasks through different tool interfaces:

| condition | interface |
|---|---|
| `cli` | this repo's `asana` CLI via `Bash(asana:*)` |
| `mcp` | official Asana MCP (`mcp.asana.com/v2/mcp`) with tool search |
| `mcp-eager` | same MCP, all schemas loaded upfront |
| `executor` | executor.sh hosted MCP proxy (code-mode) |
| `executor-cli` | the same proxy driven through its CLI via Bash |

Methodology (ported from Kun Chen's GitHub benchmark): identical prompts and model per condition, isolated headless `claude -p` sessions (`--strict-mcp-config`, fresh temp cwd, project-only setting sources), fixtures seeded and success verified **out-of-band via the Asana REST API** — never through the interface under test. Results land in JSONL with a median report per condition × task.

## Example results (sonnet, 4 tasks × 3 runs × 4 conditions)

| condition | success | cost (med) | time (med) | turns |
|---|---|---|---|---|
| `mcp-eager` | 100% | **$0.151** | **16.4s** | **4** |
| `cli` | 100% | $0.185 | 44.9s | 11.5 |
| `mcp` | 100% | $0.217 | 19.7s | 5 |
| `executor` | 83% | $0.416 | 52.2s | 12.5 |

The CLI is cheapest-or-close on simple read/write tasks but blows up on the scan-style aggregation task (21 turns, $0.350) because `task list` lacks field expansion and aggregation — quantifies and motivates #88. Once #88 lands, this harness can measure the improvement directly.

## Notes

- No production code touched; `bench/` is standalone (zero new dependencies, Bun only). `bench/results/` is gitignored.
- Prerequisites (PAT, MCP OAuth, executor setup) are documented in `bench/README.md`, including the executor approval-policy caveat for headless runs.
- `bench/` passes `eslint` and adds no `tsc` errors (the repo's existing `tsc --noEmit` failures on `src/**` are untouched).

Refs #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark suite for evaluating Asana agent workflows across multiple connection modes.
  * Introduced support for running repeated tasks, collecting results, and generating summary reports.
  * Expanded benchmark coverage with several task types, including read, create, multi-step, and aggregation scenarios.

* **Documentation**
  * Added setup and usage guidance for running the benchmark and reviewing results.

* **Bug Fixes**
  * Improved cleanup and result handling so benchmark runs are easier to repeat and analyze.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->