### PR TITLE
fix(auth): keep refresh token when refresh response omits refresh_token

### DIFF
--- a/src/lib/asana-client.ts
+++ b/src/lib/asana-client.ts
@@ -428,7 +428,10 @@ export async function refreshTokenIfNeeded(): Promise<boolean> {
     saveConfig({
       ...config,
       accessToken: tokenResponse.access_token,
-      refreshToken: tokenResponse.refresh_token,
+      // Asana does not rotate refresh tokens: the refresh_token grant response
+      // omits the field. Keep the stored one or auto-refresh breaks after the
+      // first renewal.
+      refreshToken: tokenResponse.refresh_token ?? config.refreshToken,
       expiresAt: Date.now() + (tokenResponse.expires_in * 1000),
     })
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -62,7 +62,11 @@ export function buildAuthorizeUrl(params: {
 
 export interface OAuthTokenResponse {
   access_token: string
-  refresh_token: string
+  /**
+   * Present on the authorization_code grant. Asana does not rotate refresh
+   * tokens, so the refresh_token grant response omits this field.
+   */
+  refresh_token?: string
   expires_in: number
   token_type: string
 }

--- a/test/lib/asana-client.test.ts
+++ b/test/lib/asana-client.test.ts
@@ -268,6 +268,46 @@ describe('asana-client module', () => {
       global.fetch = originalFetch
     })
 
+    test('keeps stored refresh token when refresh response omits refresh_token', async () => {
+      // Asana's refresh_token grant response does not rotate the refresh token,
+      // so the response has no refresh_token field. Persisting `undefined`
+      // would drop it from config.json and permanently break auto-refresh
+      // after the first renewal (login silently "expires" ~1h later).
+      const mockResponse = {
+        access_token: 'new-access-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+      }
+
+      const originalFetch = global.fetch
+      global.fetch = mock(() => {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockResponse),
+        })
+      }) as any
+
+      const config: AsanaConfig = {
+        accessToken: 'old-access-token',
+        authType: 'oauth',
+        refreshToken: 'old-refresh-token',
+        expiresAt: Date.now() - 1000, // Expired
+      }
+
+      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+      writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
+
+      const result = await refreshTokenIfNeeded()
+
+      expect(result).toBe(true)
+
+      const updatedConfig = JSON.parse(readFileSync(TEST_CONFIG_FILE, 'utf-8'))
+      expect(updatedConfig.accessToken).toBe('new-access-token')
+      expect(updatedConfig.refreshToken).toBe('old-refresh-token')
+
+      global.fetch = originalFetch
+    })
+
     test('refreshes token when it will expire soon', async () => {
       const mockResponse = {
         access_token: 'new-access-token',

--- a/test/lib/asana-client.test.ts
+++ b/test/lib/asana-client.test.ts
@@ -280,32 +280,35 @@ describe('asana-client module', () => {
       }
 
       const originalFetch = global.fetch
-      global.fetch = mock(() => {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve(mockResponse),
-        })
-      }) as any
+      try {
+        global.fetch = mock(() => {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockResponse),
+          })
+        }) as any
 
-      const config: AsanaConfig = {
-        accessToken: 'old-access-token',
-        authType: 'oauth',
-        refreshToken: 'old-refresh-token',
-        expiresAt: Date.now() - 1000, // Expired
+        const config: AsanaConfig = {
+          accessToken: 'old-access-token',
+          authType: 'oauth',
+          refreshToken: 'old-refresh-token',
+          expiresAt: Date.now() - 1000, // Expired
+        }
+
+        mkdirSync(TEST_CONFIG_DIR, { recursive: true })
+        writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
+
+        const result = await refreshTokenIfNeeded()
+
+        expect(result).toBe(true)
+
+        const updatedConfig = JSON.parse(readFileSync(TEST_CONFIG_FILE, 'utf-8'))
+        expect(updatedConfig.accessToken).toBe('new-access-token')
+        expect(updatedConfig.refreshToken).toBe('old-refresh-token')
       }
-
-      mkdirSync(TEST_CONFIG_DIR, { recursive: true })
-      writeFileSync(TEST_CONFIG_FILE, JSON.stringify(config))
-
-      const result = await refreshTokenIfNeeded()
-
-      expect(result).toBe(true)
-
-      const updatedConfig = JSON.parse(readFileSync(TEST_CONFIG_FILE, 'utf-8'))
-      expect(updatedConfig.accessToken).toBe('new-access-token')
-      expect(updatedConfig.refreshToken).toBe('old-refresh-token')
-
-      global.fetch = originalFetch
+      finally {
+        global.fetch = originalFetch
+      }
     })
 
     test('refreshes token when it will expire soon', async () => {


### PR DESCRIPTION
## Summary

Asana's OAuth `refresh_token` grant response omits `refresh_token` in the response body. The existing code was overwriting/dropping the previously stored refresh token whenever a refresh response omitted a new one. Once the access token subsequently expired too, there was no valid token pair left to refresh with, silently logging the user out.

This fixes the user-reported issue: 로그인 후 일정 시간 후 로그인이 풀리는 문제 (login silently expires/logs out after some time, ~1 hour, when using OAuth token login).

Fix: keep the existing refresh token when the refresh response doesn't include a new one.

## Related issue

No specific tracked issue number — this addresses the user-reported bug: "token 사용해서 로그인시 일정시간후 로그인 풀림" (로그인 후 일정 시간 후 로그인이 풀리는 문제).

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`)
- [x] Lint/format pass (`bun run lint`)
- [ ] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains the stored OAuth refresh token when Asana’s refresh response omits `refresh_token`, preventing silent logout after the next access token expiry (~1 hour). Adds a regression test and restores `global.fetch` in tests to avoid pollution.

- **Bug Fixes**
  - Keep existing `refreshToken` when refresh responses omit `refresh_token`.
  - Make `refresh_token` optional in `OAuthTokenResponse` with documentation.
  - Add regression test and restore `global.fetch` in `finally` to prevent test pollution.

<sup>Written for commit 2648bd916cf21b9aa5073d686920c7d28e7bde29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

