### PR TITLE
chore(skills): add run-asana skill to drive the CLI against a mock API

### DIFF
--- a/.claude/skills/run-asana/SKILL.md
+++ b/.claude/skills/run-asana/SKILL.md
@@ -103,8 +103,9 @@ bun test test/          # unit tests → 557 pass, 0 fail (~0.7s)
 ```
 
 E2E tests hit the **real** Asana API and self-skip without credentials; run them
-only with a real token: `bun run test:e2e:secure` (needs `.env` with
-`ASANA_ACCESS_TOKEN` + `ASANA_WORKSPACE`).
+only with a real token: `bun run test:e2e:secure`. Provide `ASANA_ACCESS_TOKEN` +
+`ASANA_WORKSPACE` as exported shell env vars, or via the repo's gitignored,
+dotenvx-encrypted `.env` (`bun run env:encrypt`) — never commit a plaintext token.
 
 ## Gotchas
 

--- a/.claude/skills/run-asana/SKILL.md
+++ b/.claude/skills/run-asana/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: run-asana
+description: Build, run, and drive the asana CLI. Use when asked to run asana, start it, build the binary, smoke-test it, exercise task/workspace/project commands, or verify a change works against a (mocked) Asana API without real credentials.
+---
+
+The asana CLI (`@pleaseai/asana`) is a Bun/TypeScript command-line tool for
+Asana. Entry point is `src/index.ts` (commander). Every real command needs an
+Asana access token and talks to `app.asana.com` — which you don't have in a
+headless container. So the agent path drives the CLI against an **in-process
+mock Asana API**: `.claude/skills/run-asana/mock-asana.mjs` stands up a fake API,
+`launch.ts` points the CLI's SDK at it, and `smoke.mjs` runs the whole battery.
+
+All paths below are relative to the repo root (`<unit>/`).
+
+## Prerequisites
+
+Bun only — this is a pure Bun/TS CLI with no native or GUI dependencies, so no
+`apt-get` packages are required. This container has Bun 1.3.14:
+
+```bash
+bun --version   # → 1.3.14
+```
+
+On a clean machine without Bun: `curl -fsSL https://bun.sh/install | bash`.
+
+## Setup
+
+```bash
+bun install
+```
+
+## Build
+
+Optional — only when you need the standalone compiled binary (npm ships this
+prebuilt). Produces a ~67M self-contained executable:
+
+```bash
+bun run build      # → bun build src/index.ts --compile --outfile asana
+./asana --version  # → 0.11.0
+```
+
+For iteration you don't need this; run `src/index.ts` directly (see below).
+
+## Run (agent path)
+
+**One-shot smoke test** — start the mock, drive the core task lifecycle
+(create → list → get → complete → delete) plus workspace/user/api reads, assert,
+tear down. Exit 0 = all good:
+
+```bash
+bun .claude/skills/run-asana/smoke.mjs
+# → ✓ PASS — 9 passed, 0 failed
+```
+
+**Drive commands by hand** — start the mock in the background, then point the
+launcher at it. `launch.ts` overrides the Asana SDK's hardcoded base URL so
+*every* command (SDK-backed and raw-fetch) hits the mock:
+
+```bash
+bun .claude/skills/run-asana/mock-asana.mjs > /tmp/mockurl.txt &
+until [ -s /tmp/mockurl.txt ]; do sleep 0.1; done
+URL=$(cat /tmp/mockurl.txt)
+
+ASANA_API_BASE_URL="$URL" ASANA_ACCESS_TOKEN=fake \
+  bun .claude/skills/run-asana/launch.ts -f json task create -n "Buy milk" -w 111
+# → { "task": { "status": "success", "gid": "1001", "name": "Buy milk" } }
+```
+
+The mock is stateful within one run: a task you create shows up in `task list`.
+It backs the endpoints the documented commands touch (tasks CRUD, `/users/me`,
+`/workspaces`, `/projects`) and returns `{ data: [] }` for anything else, so a
+command never crashes on an unmocked endpoint — extend `mock-asana.mjs` if you
+need richer responses.
+
+| file | role |
+|---|---|
+| `smoke.mjs` | orchestrator: starts mock, runs the assertion battery, exits 0/1 |
+| `launch.ts` | CLI entry that redirects the SDK to `ASANA_API_BASE_URL` (pass-through if unset) |
+| `mock-asana.mjs` | stateful in-memory Asana API; run standalone to print its base URL |
+
+### Direct invocation (no mock)
+
+`launch.ts` with `ASANA_API_BASE_URL` unset is a transparent pass-through, so it
+also works as a plain entry against real Asana (or just use `bun run dev`):
+
+```bash
+bun .claude/skills/run-asana/launch.ts --version   # → 0.11.0
+```
+
+## Run (human path)
+
+With a real Personal Access Token, against the live API:
+
+```bash
+export ASANA_ACCESS_TOKEN=<your-pat>
+bun run dev workspace list         # bun run src/index.ts …
+```
+
+## Test
+
+```bash
+bun test test/          # unit tests → 557 pass, 0 fail (~0.7s)
+```
+
+E2E tests hit the **real** Asana API and self-skip without credentials; run them
+only with a real token: `bun run test:e2e:secure` (needs `.env` with
+`ASANA_ACCESS_TOKEN` + `ASANA_WORKSPACE`).
+
+## Gotchas
+
+- **The SDK base URL is not env-overridable — that's why `launch.ts` exists.**
+  The `api`/`fetch` commands read `ASANA_API_BASE_URL` (see
+  `src/constants/api.ts`), but SDK-backed commands (task/workspace/project/…) use
+  the `asana` npm package's singleton `Asana.ApiClient.instance`, whose
+  `basePath` is hardcoded to `app.asana.com` with no env hook. `launch.ts`
+  overrides that singleton before importing the CLI.
+- **`launch.ts` must stay inside the project tree.** Its `import 'asana'` has to
+  resolve to the *same* `node_modules` copy the CLI loads. A copy in `/tmp`
+  resolves `asana` to a different module instance, Bun gives you two singletons,
+  and the basePath override silently does nothing (you get `Authentication
+  failed` instead of mock data). A Bun `--preload` module has the same split-
+  instance problem — don't use preload for this.
+- **`api` command host allowlist.** The `api` command refuses to send
+  credentials to a non-Asana host; when `ASANA_API_BASE_URL` points at your mock,
+  that mock's host becomes the allowed one, so `api /users/me` works against it.
+- **Default output is TOON, not JSON.** Commands print TOON (token-efficient)
+  unless you pass `-f json` or `-f plain`. Assert on `-f json` output when you
+  need to parse.
+- **`global.fetch` mock leakage in tests.** Bun's `mock.restore()` does not undo
+  a direct `global.fetch = mock(...)` assignment; capture and restore the
+  original in `afterEach`, or a leaked 404 mock breaks later files in the suite.
+
+## Troubleshooting
+
+- **`✗ Authentication failed` / `AUTH_FAILED` when driving via a mock**: the SDK
+  basePath wasn't redirected — the request went to real `app.asana.com` and got
+  401. Make sure you invoked `launch.ts` (not `src/index.ts`) and that
+  `ASANA_API_BASE_URL` is exported. If you copied `launch.ts` elsewhere, move it
+  back under the project so `asana` resolves to the project's `node_modules`.
+- **`file exists` on `>` redirects (zsh)**: this shell has `noclobber`; use
+  `>|` or `rm -f` the target first (the driver scripts avoid `>` for this reason).

--- a/.claude/skills/run-asana/launch.ts
+++ b/.claude/skills/run-asana/launch.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env bun
+/**
+ * CLI launcher that can redirect the Asana SDK at a mock server.
+ *
+ * The `api` and `fetch` commands read the base URL from ASANA_API_BASE_URL, but
+ * the SDK-backed commands (task/workspace/project/…) talk to the singleton
+ * `Asana.ApiClient.instance`, whose basePath is hardcoded to app.asana.com and
+ * has no env hook. This shim overrides that singleton *before* loading the CLI,
+ * so every command — SDK-backed or raw-fetch — targets ASANA_API_BASE_URL.
+ *
+ * Must live INSIDE the project tree: `import 'asana'` has to resolve to the same
+ * node_modules copy the CLI loads, or Bun gives us a second module instance and
+ * the override is lost (the two imports must share one singleton).
+ *
+ * With ASANA_API_BASE_URL unset this is a transparent pass-through equivalent to
+ * `bun src/index.ts …`, so it is safe to use as a general CLI entry too.
+ *
+ * Usage (args after the script are the normal CLI args):
+ *   ASANA_API_BASE_URL=http://localhost:PORT/api/1.0 ASANA_ACCESS_TOKEN=fake \
+ *     bun .claude/skills/run-asana/launch.ts -f json task list -w 111 -a me
+ */
+import Asana from 'asana'
+
+const base = process.env.ASANA_API_BASE_URL
+if (base) {
+  Asana.ApiClient.instance.basePath = base.replace(/\/+$/, '')
+}
+
+// Load the real CLI entry; it parses process.argv on import. argv[1] is this
+// script, so commander sees the same arg vector as `bun src/index.ts <args>`.
+await import('../../../src/index.ts')

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -54,7 +54,8 @@ export function startMock() {
       return json({ data: tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' } })
     }
     if (method === 'PUT') {
-      const updated = { ...(tasks.get(gid) ?? { gid }), ...body?.data }
+      const base = tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' }
+      const updated = { ...base, ...body?.data }
       tasks.set(gid, updated)
       return json({ data: updated })
     }
@@ -80,8 +81,9 @@ export function startMock() {
     if (path === '/workspaces') {
       return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
     }
-    if (/^\/workspaces\/[\w-]+$/.test(path)) {
-      return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
+    const match = path.match(/^\/workspaces\/([\w-]+)$/)
+    if (match) {
+      return json({ data: { gid: match[1], name: 'My Workspace', resource_type: 'workspace' } })
     }
     return null
   }

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -24,7 +24,7 @@ export function startMock() {
   ])
   let seq = 1000
 
-  const json = data => Response.json(data)
+  const json = (data, status = 200) => Response.json(data, { status })
 
   const server = Bun.serve({
     port: 0,
@@ -32,8 +32,12 @@ export function startMock() {
       const url = new URL(req.url)
       const path = url.pathname.replace(/^.*\/api\/1\.0/, '') // strip base prefix
       const method = req.method
+      // Only body-bearing methods carry JSON; parsing a bodyless GET/DELETE
+      // would throw needlessly.
       let body = null
-      try { body = await req.json() } catch { /* GET/DELETE have no body */ }
+      if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+        try { body = await req.json() } catch { /* malformed body — leave null */ }
+      }
 
       // --- Tasks ---------------------------------------------------------
       if (path === '/tasks' && method === 'POST') {
@@ -43,9 +47,16 @@ export function startMock() {
         return json({ data: task })
       }
       if (path === '/tasks' && method === 'GET') {
+        // Real Asana scopes a task list by workspace+assignee or by project.
+        // Reject a scopeless list so a CLI bug that drops the filter surfaces
+        // here instead of silently passing against the full store.
+        if (!url.searchParams.has('workspace') && !url.searchParams.has('project')) {
+          return json({ errors: [{ message: 'Missing required parameter: workspace or project' }] }, 400)
+        }
         return json({ data: [...tasks.values()] })
       }
-      const taskMatch = path.match(/^\/tasks\/(\d+)$/)
+      // Asana GIDs are opaque strings, not necessarily numeric — match \w+.
+      const taskMatch = path.match(/^\/tasks\/(\w+)$/)
       if (taskMatch) {
         const gid = taskMatch[1]
         if (method === 'GET') {
@@ -75,12 +86,14 @@ export function startMock() {
       if (path === '/workspaces') {
         return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
       }
-      if (path.match(/^\/workspaces\/\d+$/)) {
+      if (path.match(/^\/workspaces\/\w+$/)) {
         return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
       }
 
       // --- Projects ------------------------------------------------------
-      if (path.endsWith('/projects') && method === 'GET') {
+      // Only the real project-list paths: top-level, or workspace/team-scoped.
+      // A broad endsWith('/projects') would also swallow /tasks/{gid}/projects.
+      if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/\w+\/projects$/.test(path))) {
         return json({ data: [...projects.values()] })
       }
 
@@ -97,6 +110,5 @@ if (import.meta.main) {
   const mock = startMock()
   process.stdout.write(`${mock.url}\n`)
   process.stderr.write(`[mock-asana] listening on ${mock.url} — Ctrl-C to stop\n`)
-  // Keep the process alive.
-  await new Promise(() => {})
+  // Bun.serve keeps the event loop alive, so the process stays up until Ctrl-C.
 }

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -91,6 +91,12 @@ export function startMock() {
     if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/\w+\/projects$/.test(path))) {
       return json({ data: [...projects.values()] })
     }
+    // Single-project fetch (`project get <gid>`), mirroring the task/user path.
+    const match = path.match(/^\/projects\/(\w+)$/)
+    if (match && method === 'GET') {
+      const gid = match[1]
+      return json({ data: projects.get(gid) ?? { gid, name: `Project ${gid}`, resource_type: 'project' } })
+    }
     return null
   }
 

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -45,8 +45,9 @@ export function startMock() {
       }
       return json({ data: [...tasks.values()] })
     }
-    // Asana GIDs are opaque strings, not necessarily numeric — match \w+.
-    const match = path.match(/^\/tasks\/(\w+)$/)
+    // Asana GIDs are opaque strings — numeric in prod, but hyphenated in mock
+    // setups (e.g. `task-1`), so match [\w-]+.
+    const match = path.match(/^\/tasks\/([\w-]+)$/)
     if (!match) return null
     const gid = match[1]
     if (method === 'GET') {
@@ -68,7 +69,7 @@ export function startMock() {
     if (path === '/users/me') {
       return json({ data: { gid: '999', name: 'Mock User', email: 'mock@example.com', resource_type: 'user' } })
     }
-    const match = path.match(/^\/users\/(\w+)$/)
+    const match = path.match(/^\/users\/([\w-]+)$/)
     if (match) {
       return json({ data: { gid: match[1], name: 'Mock User', resource_type: 'user' } })
     }
@@ -79,7 +80,7 @@ export function startMock() {
     if (path === '/workspaces') {
       return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
     }
-    if (/^\/workspaces\/\w+$/.test(path)) {
+    if (/^\/workspaces\/[\w-]+$/.test(path)) {
       return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
     }
     return null
@@ -88,11 +89,11 @@ export function startMock() {
   function handleProjects(path, method) {
     // Only the real project-list paths: top-level, or workspace/team-scoped.
     // A broad endsWith('/projects') would also swallow /tasks/{gid}/projects.
-    if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/\w+\/projects$/.test(path))) {
+    if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/[\w-]+\/projects$/.test(path))) {
       return json({ data: [...projects.values()] })
     }
     // Single-project fetch (`project get <gid>`), mirroring the task/user path.
-    const match = path.match(/^\/projects\/(\w+)$/)
+    const match = path.match(/^\/projects\/([\w-]+)$/)
     if (match && method === 'GET') {
       const gid = match[1]
       return json({ data: projects.get(gid) ?? { gid, name: `Project ${gid}`, resource_type: 'project' } })

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -17,6 +17,8 @@
  * Or import { startMock } from a driver (see smoke.mjs).
  */
 
+const json = (data, status = 200) => Response.json(data, { status })
+
 export function startMock() {
   const tasks = new Map()
   const projects = new Map([
@@ -24,7 +26,73 @@ export function startMock() {
   ])
   let seq = 1000
 
-  const json = (data, status = 200) => Response.json(data, { status })
+  // Each handler owns one resource group and returns a Response for a path it
+  // recognizes, or null to let the next handler try. Keeps every function and
+  // the fetch dispatcher well under the 50-LOC limit.
+  function handleTasks(path, method, url, body) {
+    if (path === '/tasks' && method === 'POST') {
+      const gid = String(++seq)
+      const task = { gid, completed: false, resource_type: 'task', ...body?.data }
+      tasks.set(gid, task)
+      return json({ data: task })
+    }
+    if (path === '/tasks' && method === 'GET') {
+      // Real Asana scopes a task list by workspace+assignee or by project.
+      // Reject a scopeless list so a CLI bug that drops the filter surfaces
+      // here instead of silently passing against the full store.
+      if (!url.searchParams.has('workspace') && !url.searchParams.has('project')) {
+        return json({ errors: [{ message: 'Missing required parameter: workspace or project' }] }, 400)
+      }
+      return json({ data: [...tasks.values()] })
+    }
+    // Asana GIDs are opaque strings, not necessarily numeric — match \w+.
+    const match = path.match(/^\/tasks\/(\w+)$/)
+    if (!match) return null
+    const gid = match[1]
+    if (method === 'GET') {
+      return json({ data: tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' } })
+    }
+    if (method === 'PUT') {
+      const updated = { ...(tasks.get(gid) ?? { gid }), ...body?.data }
+      tasks.set(gid, updated)
+      return json({ data: updated })
+    }
+    if (method === 'DELETE') {
+      tasks.delete(gid)
+      return json({ data: {} })
+    }
+    return null
+  }
+
+  function handleUsers(path) {
+    if (path === '/users/me') {
+      return json({ data: { gid: '999', name: 'Mock User', email: 'mock@example.com', resource_type: 'user' } })
+    }
+    const match = path.match(/^\/users\/(\w+)$/)
+    if (match) {
+      return json({ data: { gid: match[1], name: 'Mock User', resource_type: 'user' } })
+    }
+    return null
+  }
+
+  function handleWorkspaces(path) {
+    if (path === '/workspaces') {
+      return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
+    }
+    if (/^\/workspaces\/\w+$/.test(path)) {
+      return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
+    }
+    return null
+  }
+
+  function handleProjects(path, method) {
+    // Only the real project-list paths: top-level, or workspace/team-scoped.
+    // A broad endsWith('/projects') would also swallow /tasks/{gid}/projects.
+    if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/\w+\/projects$/.test(path))) {
+      return json({ data: [...projects.values()] })
+    }
+    return null
+  }
 
   const server = Bun.serve({
     port: 0,
@@ -39,66 +107,13 @@ export function startMock() {
         try { body = await req.json() } catch { /* malformed body — leave null */ }
       }
 
-      // --- Tasks ---------------------------------------------------------
-      if (path === '/tasks' && method === 'POST') {
-        const gid = String(++seq)
-        const task = { gid, completed: false, resource_type: 'task', ...body?.data }
-        tasks.set(gid, task)
-        return json({ data: task })
-      }
-      if (path === '/tasks' && method === 'GET') {
-        // Real Asana scopes a task list by workspace+assignee or by project.
-        // Reject a scopeless list so a CLI bug that drops the filter surfaces
-        // here instead of silently passing against the full store.
-        if (!url.searchParams.has('workspace') && !url.searchParams.has('project')) {
-          return json({ errors: [{ message: 'Missing required parameter: workspace or project' }] }, 400)
-        }
-        return json({ data: [...tasks.values()] })
-      }
-      // Asana GIDs are opaque strings, not necessarily numeric — match \w+.
-      const taskMatch = path.match(/^\/tasks\/(\w+)$/)
-      if (taskMatch) {
-        const gid = taskMatch[1]
-        if (method === 'GET') {
-          return json({ data: tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' } })
-        }
-        if (method === 'PUT') {
-          const updated = { ...(tasks.get(gid) ?? { gid }), ...body?.data }
-          tasks.set(gid, updated)
-          return json({ data: updated })
-        }
-        if (method === 'DELETE') {
-          tasks.delete(gid)
-          return json({ data: {} })
-        }
-      }
-
-      // --- Users ---------------------------------------------------------
-      if (path === '/users/me') {
-        return json({ data: { gid: '999', name: 'Mock User', email: 'mock@example.com', resource_type: 'user' } })
-      }
-      const userMatch = path.match(/^\/users\/(\w+)$/)
-      if (userMatch) {
-        return json({ data: { gid: userMatch[1], name: 'Mock User', resource_type: 'user' } })
-      }
-
-      // --- Workspaces ----------------------------------------------------
-      if (path === '/workspaces') {
-        return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
-      }
-      if (path.match(/^\/workspaces\/\w+$/)) {
-        return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
-      }
-
-      // --- Projects ------------------------------------------------------
-      // Only the real project-list paths: top-level, or workspace/team-scoped.
-      // A broad endsWith('/projects') would also swallow /tasks/{gid}/projects.
-      if (method === 'GET' && (path === '/projects' || /^\/(workspaces|teams)\/\w+\/projects$/.test(path))) {
-        return json({ data: [...projects.values()] })
-      }
-
-      // --- Fallback: never crash the CLI on an unmocked read -------------
-      return json({ data: [] })
+      // Fall through the handlers in order; the last arm never crashes the CLI
+      // on an unmocked read.
+      return handleTasks(path, method, url, body)
+        ?? handleUsers(path)
+        ?? handleWorkspaces(path)
+        ?? handleProjects(path, method)
+        ?? json({ data: [] })
     },
   })
 

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -29,6 +29,8 @@ export function startMock() {
   // Each handler owns one resource group and returns a Response for a path it
   // recognizes, or null to let the next handler try. Keeps every function and
   // the fetch dispatcher well under the 50-LOC limit.
+  const defaultTask = gid => ({ gid, name: `Task ${gid}`, completed: false, resource_type: 'task' })
+
   function handleTasks(path, method, url, body) {
     if (path === '/tasks' && method === 'POST') {
       const gid = String(++seq)
@@ -51,11 +53,10 @@ export function startMock() {
     if (!match) return null
     const gid = match[1]
     if (method === 'GET') {
-      return json({ data: tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' } })
+      return json({ data: tasks.get(gid) ?? defaultTask(gid) })
     }
     if (method === 'PUT') {
-      const base = tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' }
-      const updated = { ...base, ...body?.data }
+      const updated = { ...(tasks.get(gid) ?? defaultTask(gid)), ...body?.data }
       tasks.set(gid, updated)
       return json({ data: updated })
     }

--- a/.claude/skills/run-asana/mock-asana.mjs
+++ b/.claude/skills/run-asana/mock-asana.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * Stateful in-memory mock of the Asana REST API (v1.0), just enough to drive
+ * the asana CLI end-to-end in a headless container with no real credentials.
+ *
+ * It is deliberately small: a task store that supports create/list/get/update/
+ * delete, plus canned responses for the workspace/user/project endpoints the
+ * documented commands touch. Everything else returns `{ data: [] }` so a command
+ * never crashes on an unmocked endpoint.
+ *
+ * Run standalone to drive the CLI by hand:
+ *   bun .claude/skills/run-asana/mock-asana.mjs            # prints its base URL
+ * then in another shell point the launcher at it:
+ *   ASANA_API_BASE_URL=<url> ASANA_ACCESS_TOKEN=fake \
+ *     bun .claude/skills/run-asana/launch.ts -f json workspace list
+ *
+ * Or import { startMock } from a driver (see smoke.mjs).
+ */
+
+export function startMock() {
+  const tasks = new Map()
+  const projects = new Map([
+    ['555', { gid: '555', name: 'Demo Project', resource_type: 'project' }],
+  ])
+  let seq = 1000
+
+  const json = data => Response.json(data)
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url)
+      const path = url.pathname.replace(/^.*\/api\/1\.0/, '') // strip base prefix
+      const method = req.method
+      let body = null
+      try { body = await req.json() } catch { /* GET/DELETE have no body */ }
+
+      // --- Tasks ---------------------------------------------------------
+      if (path === '/tasks' && method === 'POST') {
+        const gid = String(++seq)
+        const task = { gid, completed: false, resource_type: 'task', ...body?.data }
+        tasks.set(gid, task)
+        return json({ data: task })
+      }
+      if (path === '/tasks' && method === 'GET') {
+        return json({ data: [...tasks.values()] })
+      }
+      const taskMatch = path.match(/^\/tasks\/(\d+)$/)
+      if (taskMatch) {
+        const gid = taskMatch[1]
+        if (method === 'GET') {
+          return json({ data: tasks.get(gid) ?? { gid, name: `Task ${gid}`, completed: false, resource_type: 'task' } })
+        }
+        if (method === 'PUT') {
+          const updated = { ...(tasks.get(gid) ?? { gid }), ...body?.data }
+          tasks.set(gid, updated)
+          return json({ data: updated })
+        }
+        if (method === 'DELETE') {
+          tasks.delete(gid)
+          return json({ data: {} })
+        }
+      }
+
+      // --- Users ---------------------------------------------------------
+      if (path === '/users/me') {
+        return json({ data: { gid: '999', name: 'Mock User', email: 'mock@example.com', resource_type: 'user' } })
+      }
+      const userMatch = path.match(/^\/users\/(\w+)$/)
+      if (userMatch) {
+        return json({ data: { gid: userMatch[1], name: 'Mock User', resource_type: 'user' } })
+      }
+
+      // --- Workspaces ----------------------------------------------------
+      if (path === '/workspaces') {
+        return json({ data: [{ gid: '111', name: 'My Workspace', resource_type: 'workspace' }] })
+      }
+      if (path.match(/^\/workspaces\/\d+$/)) {
+        return json({ data: { gid: '111', name: 'My Workspace', resource_type: 'workspace' } })
+      }
+
+      // --- Projects ------------------------------------------------------
+      if (path.endsWith('/projects') && method === 'GET') {
+        return json({ data: [...projects.values()] })
+      }
+
+      // --- Fallback: never crash the CLI on an unmocked read -------------
+      return json({ data: [] })
+    },
+  })
+
+  const url = `http://localhost:${server.port}/api/1.0`
+  return { url, port: server.port, stop: () => server.stop(true) }
+}
+
+if (import.meta.main) {
+  const mock = startMock()
+  process.stdout.write(`${mock.url}\n`)
+  process.stderr.write(`[mock-asana] listening on ${mock.url} — Ctrl-C to stop\n`)
+  // Keep the process alive.
+  await new Promise(() => {})
+}

--- a/.claude/skills/run-asana/smoke.mjs
+++ b/.claude/skills/run-asana/smoke.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end smoke driver for the asana CLI.
+ *
+ * Starts an in-process mock Asana API (mock-asana.mjs), then runs a battery of
+ * real CLI invocations against it through launch.ts — exercising command
+ * parsing, token resolution, SDK/raw-fetch request building, and TOON/JSON
+ * output formatting — with no real Asana credentials. Drives the core task
+ * lifecycle (create → list → get → complete → delete) plus workspace/user reads.
+ *
+ * Run:  bun .claude/skills/run-asana/smoke.mjs
+ * Exit: 0 if every check passes, 1 otherwise (prints a PASS/FAIL summary).
+ */
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { startMock } from './mock-asana.mjs'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const launcher = resolve(here, 'launch.ts')
+
+const mock = startMock()
+const env = { ...process.env, ASANA_API_BASE_URL: mock.url, ASANA_ACCESS_TOKEN: 'fake-token-for-mock' }
+
+let passed = 0
+let failed = 0
+
+async function cli(args) {
+  const proc = Bun.spawn(['bun', launcher, ...args], { env, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+  const code = await proc.exited
+  return { code, stdout, stderr, out: stdout + stderr }
+}
+
+function check(name, ok, detail = '') {
+  if (ok) {
+    passed++
+    console.log(`  ✓ ${name}`)
+  }
+  else {
+    failed++
+    console.log(`  ✗ ${name}${detail ? `\n      ${detail.replace(/\n/g, '\n      ')}` : ''}`)
+  }
+}
+
+try {
+  console.log(`\nmock Asana API → ${mock.url}\n`)
+
+  // 1. Version — no network, proves the binary parses and runs.
+  {
+    const r = await cli(['--version'])
+    check('asana --version exits 0 and prints a version', r.code === 0 && /\d+\.\d+\.\d+/.test(r.out), r.out.trim())
+  }
+
+  // 2. Workspace list (SDK-backed, redirected via launch.ts).
+  {
+    const r = await cli(['-f', 'json', 'workspace', 'list'])
+    check('workspace list returns the mocked workspace', r.code === 0 && r.out.includes('My Workspace'), r.out.trim())
+  }
+
+  // 3. Create a task (SDK POST /tasks) and capture its gid.
+  let gid = null
+  {
+    const r = await cli(['-f', 'json', 'task', 'create', '-n', 'Buy milk', '-w', '111'])
+    try { gid = JSON.parse(r.stdout).task?.gid } catch { /* leave null */ }
+    check('task create succeeds and returns a gid', r.code === 0 && Boolean(gid), r.out.trim())
+  }
+
+  // 4. List tasks — the created task is now in the mock's store.
+  {
+    const r = await cli(['-f', 'json', 'task', 'list', '-w', '111', '-a', 'me'])
+    check('task list includes the created task', r.code === 0 && r.out.includes('Buy milk'), r.out.trim())
+  }
+
+  // 5. Get the task by gid.
+  if (gid) {
+    const r = await cli(['-f', 'json', 'task', 'get', gid])
+    check('task get returns the task by gid', r.code === 0 && r.out.includes(gid), r.out.trim())
+  }
+
+  // 6. api command (raw-fetch path, honors ASANA_API_BASE_URL directly).
+  {
+    const r = await cli(['-f', 'json', 'api', '/users/me'])
+    check('api /users/me returns the mocked user', r.code === 0 && r.out.includes('Mock User'), r.out.trim())
+  }
+
+  // 7. Complete then delete the task (SDK PUT + DELETE).
+  if (gid) {
+    const c = await cli(['task', 'complete', gid])
+    check('task complete exits 0', c.code === 0, c.out.trim())
+    const d = await cli(['task', 'delete', gid])
+    check('task delete exits 0', d.code === 0, d.out.trim())
+  }
+
+  // 8. Default TOON output format (no -f flag) still renders.
+  {
+    const r = await cli(['workspace', 'list'])
+    check('default (TOON) workspace list renders the workspace', r.code === 0 && r.out.includes('My Workspace'), r.out.trim())
+  }
+}
+finally {
+  mock.stop()
+}
+
+console.log(`\n${failed === 0 ? '✓ PASS' : '✗ FAIL'} — ${passed} passed, ${failed} failed\n`)
+process.exit(failed === 0 ? 0 : 1)

--- a/.claude/skills/run-asana/smoke.mjs
+++ b/.claude/skills/run-asana/smoke.mjs
@@ -24,13 +24,16 @@ const env = { ...process.env, ASANA_API_BASE_URL: mock.url, ASANA_ACCESS_TOKEN: 
 let passed = 0
 let failed = 0
 
-async function cli(args) {
+async function cli(args, timeoutMs = 15_000) {
   const proc = Bun.spawn(['bun', launcher, ...args], { env, stdout: 'pipe', stderr: 'pipe' })
+  // Guard against a hung invocation so an unattended run can't block forever.
+  const timer = setTimeout(() => proc.kill(), timeoutMs)
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ])
   const code = await proc.exited
+  clearTimeout(timer)
   return { code, stdout, stderr, out: stdout + stderr }
 }
 
@@ -54,9 +57,10 @@ try {
     check('asana --version exits 0 and prints a version', r.code === 0 && /\d+\.\d+\.\d+/.test(r.out), r.out.trim())
   }
 
-  // 2. Workspace list (SDK-backed, redirected via launch.ts).
+  // 2. Workspace list (SDK-backed, redirected via launch.ts). --no-cache so the
+  //    assertion exercises the mock, not a stale ~/.asana-cli/cache.json entry.
   {
-    const r = await cli(['-f', 'json', 'workspace', 'list'])
+    const r = await cli(['-f', 'json', 'workspace', 'list', '--no-cache'])
     check('workspace list returns the mocked workspace', r.code === 0 && r.out.includes('My Workspace'), r.out.trim())
   }
 
@@ -74,10 +78,13 @@ try {
     check('task list includes the created task', r.code === 0 && r.out.includes('Buy milk'), r.out.trim())
   }
 
-  // 5. Get the task by gid.
-  if (gid) {
-    const r = await cli(['-f', 'json', 'task', 'get', gid])
-    check('task get returns the task by gid', r.code === 0 && r.out.includes(gid), r.out.trim())
+  // 5. Get the task by gid. When create failed (no gid) count this as a failure
+  //    rather than skipping, so a broken create doesn't shrink the tally and
+  //    read as an isolated failure.
+  {
+    const r = gid ? await cli(['-f', 'json', 'task', 'get', gid]) : null
+    check('task get returns the task by gid', Boolean(gid) && r.code === 0 && r.out.includes(gid),
+      gid ? r.out.trim() : 'skipped: task create did not return a gid')
   }
 
   // 6. api command (raw-fetch path, honors ASANA_API_BASE_URL directly).
@@ -86,17 +93,20 @@ try {
     check('api /users/me returns the mocked user', r.code === 0 && r.out.includes('Mock User'), r.out.trim())
   }
 
-  // 7. Complete then delete the task (SDK PUT + DELETE).
-  if (gid) {
-    const c = await cli(['task', 'complete', gid])
-    check('task complete exits 0', c.code === 0, c.out.trim())
-    const d = await cli(['task', 'delete', gid])
-    check('task delete exits 0', d.code === 0, d.out.trim())
+  // 7. Complete then delete the task (SDK PUT + DELETE). Count as failures when
+  //    there's no gid, so downstream breakage from a failed create stays visible.
+  {
+    const c = gid ? await cli(['task', 'complete', gid]) : null
+    check('task complete exits 0', Boolean(gid) && c.code === 0,
+      gid ? c.out.trim() : 'skipped: task create did not return a gid')
+    const d = gid ? await cli(['task', 'delete', gid]) : null
+    check('task delete exits 0', Boolean(gid) && d.code === 0,
+      gid ? d.out.trim() : 'skipped: task create did not return a gid')
   }
 
   // 8. Default TOON output format (no -f flag) still renders.
   {
-    const r = await cli(['workspace', 'list'])
+    const r = await cli(['workspace', 'list', '--no-cache'])
     check('default (TOON) workspace list renders the workspace', r.code === 0 && r.out.includes('My Workspace'), r.out.trim())
   }
 }


### PR DESCRIPTION
<!-- PR title should follow Conventional Commits, e.g. "feat(api): add pagination" -->

## Summary

Adds a Claude Code "run" skill at `.claude/skills/run-asana/` that lets an agent build, launch, and drive the `asana` CLI end-to-end on a clean machine with **no real Asana credentials**.

The CLI's Asana SDK dependency hardcodes its base URL to `app.asana.com` with no env-var hook (only the raw-fetch `api`/`fetch` commands honor `ASANA_API_BASE_URL`). To exercise SDK-backed commands headlessly, `launch.ts` overrides the SDK's singleton `Asana.ApiClient.instance.basePath` *before* importing the CLI entry point, redirecting every command — SDK-backed and raw-fetch alike — at a mock API. It must live inside the project tree so `import 'asana'` resolves to the same `node_modules` copy the CLI loads (a copy elsewhere would get a second module instance and the override would silently do nothing). When `ASANA_API_BASE_URL` is unset, `launch.ts` is a transparent pass-through and works as a normal CLI entry too.

### Files added

- `SKILL.md` — agent-facing man page (frontmatter name `run-asana`) covering setup, build, run (agent path / human path), test, gotchas, and troubleshooting.
- `launch.ts` — CLI launcher that performs the SDK basePath redirect described above.
- `mock-asana.mjs` — stateful in-memory mock of the Asana REST API (v1.0): tasks CRUD plus workspace/user/project reads, with a safe `{ data: [] }` fallback for unmocked endpoints so a command never crashes.
- `smoke.mjs` — end-to-end driver: starts the mock, drives the full task lifecycle (create → list → get → complete → delete) plus workspace/user/api reads through `launch.ts`, asserts on each step, and exits 0/1 with a pass/fail summary.

## Related issue

N/A — tooling addition, not tied to a tracked issue.

## Verification

- `bun .claude/skills/run-asana/smoke.mjs` → `✓ PASS — 9 passed, 0 failed`
- `bun run build` → compiles the standalone binary successfully
- `bun test test/` → `557 pass`, 0 fail

## Checklist

- [x] PR title follows Conventional Commits
- [x] Tests added or updated, and the suite passes (`bun run test`)
- [ ] Lint/format pass (`bun run lint`)
- [ ] Documentation updated if behavior changed
- [x] No breaking change, or a `BREAKING CHANGE:` note is included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `run-asana` skill to build, launch, and drive the `asana` CLI against a mock Asana API with no real credentials. Improves the mock to accept hyphenated GIDs, preserve default task fields on updates, and include the workspace gid.

- **New Features**
  - `launch.ts`: Sets `Asana.ApiClient.instance.basePath` from `ASANA_API_BASE_URL`; pass-through when unset.
  - `mock-asana.mjs`: Stateful mock (tasks CRUD; workspace/user/project reads) with guard rails; `{ data: [] }` fallback for unmocked reads; per-resource handlers; supports single-project GET; extracted `defaultTask` factory.
  - `smoke.mjs`: Starts the mock and runs task lifecycle plus workspace/user/api reads; adds a timeout and verifies TOON/JSON output; exits with PASS/FAIL.

- **Bug Fixes**
  - Route patterns match hyphenated GIDs across task/user/project endpoints.
  - Task updates keep default fields (e.g., `completed`, `resource_type`) and the mock reflects the provided workspace gid.

<sup>Written for commit e9bcfd0b222560299761aeae42c988d68f4cf73d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local mock Asana API and launcher support to run the Asana CLI without real credentials.
  * Introduced an end-to-end smoke-test flow covering core task operations (create, list, fetch, complete, delete).

* **Documentation**
  * Added setup, build, run, and troubleshooting guidance for both mock-based runs and real-account usage.

* **Tests**
  * Added automated checks for CLI startup, version output, workspace/project access, raw API invocation behavior, and default rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->